### PR TITLE
Fix/subscribe offset

### DIFF
--- a/rstream/consumer.py
+++ b/rstream/consumer.py
@@ -125,7 +125,10 @@ class Consumer:
         decoder = decoder or (lambda x: x)
 
         if offset_type in (OffsetType.LAST, OffsetType.NEXT):
-            offset = await self.query_offset(stream, reference)
+            try:
+                offset = await self.query_offset(stream, reference)
+            except exceptions.NoOffsetError:
+                offset = 0
 
         subscriber = self._subscribers[reference] = _Subscriber(
             stream=stream,

--- a/rstream/consumer.py
+++ b/rstream/consumer.py
@@ -127,7 +127,7 @@ class Consumer:
         if offset_type in (OffsetType.LAST, OffsetType.NEXT):
             try:
                 offset = await self.query_offset(stream, reference)
-            except exceptions.NoOffsetError:
+            except exceptions.OffsetNotFound:
                 offset = 0
 
         subscriber = self._subscribers[reference] = _Subscriber(

--- a/rstream/consumer.py
+++ b/rstream/consumer.py
@@ -200,15 +200,15 @@ class Consumer:
 
     @staticmethod
     def _filter_messages(frame: schema.Deliver, subscriber: _Subscriber) -> Iterator[bytes]:
-        minDeliverableOffset = -1
+        min_deliverable_offset = -1
         if subscriber.offset_type is OffsetType.OFFSET:
-            minDeliverableOffset = subscriber.offset
+            min_deliverable_offset = subscriber.offset
 
         offset = frame.chunk_first_offset - 1
 
         for message in frame.get_messages():
             offset += 1
-            if offset < minDeliverableOffset:
+            if offset < min_deliverable_offset:
                 continue
 
             yield message

--- a/rstream/consumer.py
+++ b/rstream/consumer.py
@@ -124,12 +124,6 @@ class Consumer:
         reference = subscriber_name or f"{stream}_subscriber_{subscription_id}"
         decoder = decoder or (lambda x: x)
 
-        if offset_type in (OffsetType.LAST, OffsetType.NEXT):
-            try:
-                offset = await self.query_offset(stream, reference)
-            except exceptions.OffsetNotFound:
-                offset = 0
-
         subscriber = self._subscribers[reference] = _Subscriber(
             stream=stream,
             subscription_id=subscription_id,
@@ -189,6 +183,9 @@ class Consumer:
         del self._subscribers[subscriber_name]
 
     async def query_offset(self, stream: str, subscriber_name: str) -> int:
+        if subscriber_name == "":
+            raise ValueError("subscriber_name must not be an empty string")
+
         return await self.default_client.query_offset(
             stream,
             subscriber_name,

--- a/rstream/consumer.py
+++ b/rstream/consumer.py
@@ -200,23 +200,20 @@ class Consumer:
 
     @staticmethod
     def _filter_messages(frame: schema.Deliver, subscriber: _Subscriber) -> Iterator[bytes]:
-        if subscriber.offset_type is OffsetType.TIMESTAMP:
-            if frame.timestamp < subscriber.offset:
-                yield from ()
-            else:
-                yield from frame.get_messages()
+        minDeliverableOffset = -1
+        if subscriber.offset_type is OffsetType.OFFSET:
+            minDeliverableOffset = subscriber.offset
 
-        else:
-            offset = frame.chunk_first_offset - 1
-            if subscriber.offset_type is OffsetType.NEXT:
-                offset -= 1
+        offset = frame.chunk_first_offset - 1
 
-            for message in frame.get_messages():
-                offset += 1
-                if offset >= subscriber.offset:
-                    yield message
+        for message in frame.get_messages():
+            offset += 1
+            if offset < minDeliverableOffset:
+                continue
 
-            subscriber.offset = frame.chunk_first_offset + frame.num_entries
+            yield message
+
+        subscriber.offset = frame.chunk_first_offset + frame.num_entries
 
     async def _on_deliver(self, frame: schema.Deliver, subscriber: _Subscriber) -> None:
         if frame.subscription_id != subscriber.subscription_id:

--- a/rstream/exceptions.py
+++ b/rstream/exceptions.py
@@ -81,3 +81,6 @@ class PreconditionFailed(ServerError):
 
 class PublisherDoesNotExist(ServerError):
     code = 18
+
+class NoOffsetError(ServerError):
+    code = 19

--- a/rstream/exceptions.py
+++ b/rstream/exceptions.py
@@ -82,5 +82,5 @@ class PreconditionFailed(ServerError):
 class PublisherDoesNotExist(ServerError):
     code = 18
 
-class NoOffsetError(ServerError):
+class OffsetNotFound(ServerError):
     code = 19

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -120,7 +120,7 @@ async def test_offset_type_timestamp(stream: str, consumer: Consumer, producer: 
         offset=now
     )
 
-    await wait_for(lambda: captured[0] >= b"5000")
+    await wait_for(lambda: len(captured) > 0 and captured[0] >= b"5000")
 
 
 async def test_offset_type_next(stream: str, consumer: Consumer, producer: Producer) -> None:

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -86,7 +86,7 @@ async def test_offset_type_last(stream: str, consumer: Consumer, producer: Produ
         subscriber_name="test-subscriber",
     )
 
-    await wait_for(lambda: captured[-1] == b"4999")
+    await wait_for(lambda: len(captured) > 0 and captured[-1] == b"4999")
     assert len(captured) < len(messages)
 
 

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -86,9 +86,8 @@ async def test_offset_type_last(stream: str, consumer: Consumer, producer: Produ
         subscriber_name="test-subscriber",
     )
 
-    await asyncio.sleep(0.1)
+    await wait_for(lambda: captured[-1] == b"4999")
     assert len(captured) < len(messages)
-    assert captured[-1] == b"4999"
 
 
 async def test_offset_type_next(stream: str, consumer: Consumer, producer: Producer) -> None:

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -120,7 +120,7 @@ async def test_offset_type_timestamp(stream: str, consumer: Consumer, producer: 
         offset=now
     )
 
-    await wait_for(lambda: len(captured) > 0 and captured[0] >= b"5000")
+    await wait_for(lambda: len(captured) > 0 and captured[0] > b"1")
 
 
 async def test_offset_type_next(stream: str, consumer: Consumer, producer: Producer) -> None:

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -75,7 +75,9 @@ async def test_offset_type_offset(stream: str, consumer: Consumer, producer: Pro
 
 
 async def test_offset_type_last(stream: str, consumer: Consumer, producer: Producer) -> None:
-    await consumer.store_offset(stream, "test-subscriber", offset=7)
+    messages = [str(i).encode() for i in range(1, 5_000)]
+    await producer.publish_batch(stream, messages)
+
     captured: list[bytes] = []
     await consumer.subscribe(
         stream,
@@ -84,15 +86,15 @@ async def test_offset_type_last(stream: str, consumer: Consumer, producer: Produ
         subscriber_name="test-subscriber",
     )
 
-    messages = [str(i).encode() for i in range(1, 11)]
-    await producer.publish_batch(stream, messages)
-
-    await wait_for(lambda: len(captured) >= 4)
-    assert captured == messages[6:]
+    await asyncio.sleep(0.1)
+    assert len(captured) < len(messages)
+    assert captured[-1] == b"4999"
 
 
 async def test_offset_type_next(stream: str, consumer: Consumer, producer: Producer) -> None:
-    await consumer.store_offset(stream, "test-subscriber", offset=7)
+    messages = [str(i).encode() for i in range(1, 11)]
+    await producer.publish_batch(stream, messages)
+
     captured: list[bytes] = []
     await consumer.subscribe(
         stream,
@@ -100,12 +102,9 @@ async def test_offset_type_next(stream: str, consumer: Consumer, producer: Produ
         offset_type=OffsetType.NEXT,
         subscriber_name="test-subscriber",
     )
-
-    messages = [str(i).encode() for i in range(1, 11)]
-    await producer.publish_batch(stream, messages)
-
-    await wait_for(lambda: len(captured) >= 3)
-    assert captured == messages[7:]
+    await producer.publish(stream, b"11")
+    await wait_for(lambda: len(captured) > 0)
+    assert captured == [b"11"]
 
 
 async def test_offset_type_timestamp(stream: str, consumer: Consumer, producer: Producer) -> None:

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -138,6 +138,18 @@ async def test_consume_with_resubscribe(stream: str, consumer: Consumer, produce
     await wait_for(lambda: len(captured) >= 2)
     assert captured == [b"one", b"two"]
 
+async def test_consume_with_resubscribe_on_last(stream: str, consumer: Consumer, producer: Producer) -> None:
+    captured: list[bytes] = []
+    subscriber_name = await consumer.subscribe(stream, callback=captured.append)
+    await producer.publish(stream, b"one")
+    await wait_for(lambda: len(captured) >= 1)
+
+    await consumer.unsubscribe(subscriber_name)
+    await consumer.subscribe(stream, callback=captured.append, offset_type=OffsetType.LAST)
+
+    await producer.publish(stream, b"two")
+    await wait_for(lambda: len(captured) >= 3)
+    assert captured == [b"one", b"one", b"two"]
 
 async def test_consume_with_restart(stream: str, consumer: Consumer, producer: Producer) -> None:
     captured: list[bytes] = []


### PR DESCRIPTION
This PR addresses several issues:

1. There was one undefined response code 19 
![image](https://user-images.githubusercontent.com/3678482/159668638-b5431ad5-bd00-4e9d-a9fa-a45bf1f0c3c0.png)
2. When subscribing to FIRST or LAST on a fresh stream, it would error out because of NoOffset. This handles the error and resets offset 0. (Question: should we store the offset at this point?)