### PR TITLE
avoiding using JRubics/poetry-publish@v1.16

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -13,14 +13,19 @@ on:
         required: true
 
 jobs:
-  publish-service-client-package:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Publish python poetry package
-        uses: JRubics/poetry-publish@v1.16
-        with:
-          repository_url: ${{ inputs.pypi_repository_url }}
-          repository_username: ${{ secrets.PYPI_LOGIN }}
-          repository_password: ${{ secrets.PYPI_PASSWORD }}
+      - name: Publish python poetry package  
+        env:
+          USER: ${{ secrets.pypi_api_login }}
+          PASS: ${{ secrets.pypi_api_password }}
+          REPO: ${{ inputs.pypi_repository_url }}
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          export PATH="/home/runner/.local/bin:$PATH"
+          poetry config repositories.test-pypi $REPO
+          poetry build
+          poetry publish --username=$USER --password=$PASS
             


### PR DESCRIPTION
I originally tried to use JRubics/poetry-publish@v1.16 but it seems like if failing with this error:

There is no pypi-token.pypi setting.



Probably a simple action like this can be fine as well