### PR TITLE
There was a bug in the previous software version.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rstream"
-version = "0.6.0"
+version = "0.7.0"
 description = "A python client for RabbitMQ Streams"
 authors = ["George Fortunatov <qweeeze@gmail.com>"]
 readme = "README.md"

--- a/tests/util.py
+++ b/tests/util.py
@@ -24,3 +24,13 @@ def on_publish_confirm_client_callback(
         confirmed_messages.append(confirmation.message_id)
     else:
         errored_messages.append(confirmation.message_id)
+
+
+def on_publish_confirm_client_callback2(
+    confirmation: ConfirmationStatus, confirmed_messages: list[int], errored_messages: list[int]
+) -> None:
+
+    if confirmation.is_confirmed is True:
+        confirmed_messages.append(confirmation.message_id)
+    else:
+        errored_messages.append(confirmation.message_id)


### PR DESCRIPTION
When specifing different publish_notification callbacks for Send/Send_Batch Just the last one was invoked.
Fixed and added tests to cover this scenario
Bumping poetry version as well to prepare delivering