### PR TITLE
Implementing consumer side of superstream 

### DIFF
--- a/docs/examples/super_stream_producer.py
+++ b/docs/examples/super_stream_producer.py
@@ -1,0 +1,23 @@
+import asyncio
+
+from rstream import AMQPMessage, SuperStreamProducer, RouteType
+
+
+async def routing_extractor(message: AMQPMessage) -> str:
+    return message.application_properties['id']
+
+
+async def publish():
+    async with SuperStreamProducer('localhost', username='guest', password='guest',
+                                   routing_extractor=routing_extractor,
+                                   routing=RouteType.Hash,
+                                   super_stream='invoices',
+                                   ) as super_stream_producer:
+        for i in range(100):
+            amqp_message = AMQPMessage(
+                body='hello: {}'.format(i),
+                application_properties={'id': '{}'.format(i)},
+            )
+            await super_stream_producer.send(amqp_message)
+
+asyncio.run(publish())

--- a/rstream/__init__.py
+++ b/rstream/__init__.py
@@ -21,7 +21,10 @@ from .producer import (  # noqa: E402
     Producer,
     RawMessage,
 )
-from .superstream import (  # noqa: E402
+from .superstream_consumer import (  # noqa: E402
+    SuperStreamConsumer,
+)
+from .superstream_producer import (  # noqa: E402
     RouteType,
     SuperStreamProducer,
 )
@@ -37,4 +40,5 @@ __all__ = [
     "CompressionType",
     "SuperStreamProducer",
     "RouteType",
+    "SuperStreamConsumer",
 ]

--- a/rstream/superstream.py
+++ b/rstream/superstream.py
@@ -2,139 +2,23 @@
 # SPDX-License-Identifier: MIT
 
 import abc
-import ssl
-from enum import Enum
 from typing import (
     Annotated,
     Any,
     Awaitable,
     Callable,
-    Optional,
     TypeVar,
 )
 
 import mmh3
 
 from .amqp import _MessageProtocol
-from .client import Client, ClientPool
-from .producer import ConfirmationStatus, Producer
-
-MT = TypeVar("MT")
-CB = Annotated[Callable[[MT], Awaitable[Any]], "Message callback type"]
+from .client import Client
 
 MessageT = TypeVar("MessageT", _MessageProtocol, bytes)
 
-
-class RouteType(Enum):
-    Hash = 0
-    Key = 1
-
-
-class SuperStreamProducer:
-    def __init__(
-        self,
-        host: str,
-        port: int = 5552,
-        *,
-        ssl_context: Optional[ssl.SSLContext] = None,
-        vhost: str = "/",
-        username: str,
-        password: str,
-        super_stream: str,
-        routing_extractor: CB[Any],
-        routing: RouteType = RouteType.Hash,
-        frame_max: int = 1 * 1024 * 1024,
-        heartbeat: int = 60,
-        load_balancer_mode: bool = False,
-        max_retries: int = 20,
-        default_batch_publishing_delay: float = 0.2,
-    ):
-        self._pool = ClientPool(
-            host,
-            port,
-            ssl_context=ssl_context,
-            vhost=vhost,
-            username=username,
-            password=password,
-            frame_max=frame_max,
-            heartbeat=heartbeat,
-            load_balancer_mode=load_balancer_mode,
-            max_retries=max_retries,
-        )
-        self.host = host
-        self.port = port
-        self.vhost = vhost
-        self.username = username
-        self.password = password
-        self.ssl_context = ssl_context
-        self.super_stream = super_stream
-        self.routing = routing
-        self.routing_extractor: CB[Any] = routing_extractor
-        self.frame_max = frame_max
-        self.heartbeat = heartbeat
-        self.load_balancer_mode = load_balancer_mode
-        self.max_retries = max_retries
-        self.default_batch_publishing_delay = default_batch_publishing_delay
-        self._default_client: Optional[Client] = None
-        self._producer: Producer | None = None
-        self._routing_strategy: RoutingStrategy
-
-    async def _get_producer(self) -> Producer:
-        if self._producer is None:
-            producer = Producer(
-                host=self.host,
-                port=self.port,
-                vhost=self.vhost,
-                username=self.username,
-                password=self.password,
-                ssl_context=self.ssl_context,
-                frame_max=self.frame_max,
-                heartbeat=self.heartbeat,
-                load_balancer_mode=self.load_balancer_mode,
-                default_batch_publishing_delay=self.default_batch_publishing_delay,
-            )
-            await producer.start()
-            self._producer = producer
-        return self._producer
-
-    async def send(
-        self,
-        message: MessageT,
-        on_publish_confirm: Optional[CB[ConfirmationStatus]] = None,
-    ) -> None:
-
-        streams = await self._routing_strategy.route(message, self.super_stream_metadata)
-        self._producer = await self._get_producer()
-
-        for stream in streams:
-            await self._producer.send(stream=stream, message=message, on_publish_confirm=on_publish_confirm)
-
-    @property
-    def default_client(self) -> Client:
-        if self._default_client is None:
-            raise ValueError("Producer is not started")
-        return self._default_client
-
-    async def __aenter__(self):
-        await self.start()
-        return self
-
-    async def __aexit__(self, *_: Any) -> None:
-        await self.close()
-
-    async def start(self) -> None:
-        self._default_client = await self._pool.get()
-        self.super_stream_metadata = DefaultSuperstreamMetadata(self.super_stream, self._default_client)
-        if self.routing == RouteType.Hash:
-            self._routing_strategy = HashRoutingMurmurStrategy(self.routing_extractor)
-        else:
-            self._routing_strategy = RoutingKeyRoutingStrategy(self.routing_extractor)
-
-    async def close(self) -> None:
-        await self._pool.close()
-        if self._producer is not None:
-            await self._producer.close()
-        self._default_client = None
+MT = TypeVar("MT")
+CB = Annotated[Callable[[MT], Awaitable[Any]], "Message callback type"]
 
 
 class Metadata(abc.ABC):
@@ -152,6 +36,10 @@ class DefaultSuperstreamMetadata(Metadata):
 
     async def partitions(self) -> list[str]:
         self._partitions = await self.client.partitions(self.super_stream)
+        if len(self._partitions) <= 0:
+            raise ValueError(
+                "the number of partitions of the stream is less or equal to 0, the superstream doesn't probably exist"
+            )
         return self._partitions
 
     async def routes(self, routing_key: str) -> list[str]:
@@ -185,8 +73,8 @@ class HashRoutingMurmurStrategy(RoutingStrategy):
         partitions = len(await metadata.partitions())
 
         route = int.from_bytes(hash, "little", signed=False) % partitions
-        streams = await metadata.partitions()
-        stream = streams[route]
+        stream_partitions = await metadata.partitions()
+        stream = stream_partitions[route]
         streams.append(stream)
 
         return streams

--- a/rstream/superstream_consumer.py
+++ b/rstream/superstream_consumer.py
@@ -1,0 +1,177 @@
+# Copyright 2023 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import asyncio
+import random
+import ssl
+from collections import defaultdict
+from typing import (
+    Annotated,
+    Any,
+    Awaitable,
+    Callable,
+    Optional,
+    TypeVar,
+    Union,
+)
+
+from .client import Addr, Client, ClientPool
+from .constants import OffsetType
+from .consumer import Consumer
+from .superstream import DefaultSuperstreamMetadata
+
+MT = TypeVar("MT")
+CB = Annotated[Callable[[MT], Union[None, Awaitable[None]]], "Message callback type"]
+
+
+class SuperStreamConsumer:
+    def __init__(
+        self,
+        host: str,
+        port: int = 5552,
+        *,
+        ssl_context: Optional[ssl.SSLContext] = None,
+        vhost: str = "/",
+        username: str,
+        password: str,
+        frame_max: int = 1 * 1024 * 1024,
+        heartbeat: int = 60,
+        load_balancer_mode: bool = False,
+        max_retries: int = 20,
+        super_stream: str,
+    ):
+        self._pool = ClientPool(
+            host,
+            port,
+            ssl_context=ssl_context,
+            vhost=vhost,
+            username=username,
+            password=password,
+            frame_max=frame_max,
+            heartbeat=heartbeat,
+            load_balancer_mode=load_balancer_mode,
+            max_retries=max_retries,
+        )
+        self._default_client: Optional[Client] = None
+        self._clients: dict[str, Client] = {}
+        self._lock = asyncio.Lock()
+        self.super_stream = super_stream
+        self.host = host
+        self.port = port
+        self.username = username
+        self.password = password
+        self.vhost = vhost
+        self.ssl_context = ssl_context
+        self.frame_max = frame_max
+        self.heartbeat = heartbeat
+        self.load_balancer_mode = load_balancer_mode
+        self.max_retries = max_retries
+        self._consumers: dict[str, Consumer] = {}
+        self._stop_event = asyncio.Event()
+        self._subscribers: dict[str, str] = defaultdict(str)
+
+    @property
+    def default_client(self) -> Client:
+        if self._default_client is None:
+            raise ValueError("Consumer is not started")
+        return self._default_client
+
+    async def __aenter__(self) -> SuperStreamConsumer:
+        await self.start()
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        await self.close()
+
+    async def start(self) -> None:
+        self._default_client = await self._pool.get()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    async def close(self) -> None:
+        for partition in self._consumers:
+            consumer = self._consumers[partition]
+            await consumer.close()
+
+        self.stop()
+        await self._pool.close()
+        self._clients.clear()
+        self._default_client = None
+
+    async def run(self) -> None:
+        await self._stop_event.wait()
+
+    async def _get_or_create_client(self, stream: str) -> Client:
+        if stream not in self._clients:
+            leader, replicas = await self.default_client.query_leader_and_replicas(stream)
+            broker = random.choice(replicas) if replicas else leader
+            self._clients[stream] = await self._pool.get(Addr(broker.host, broker.port))
+
+        return self._clients[stream]
+
+    async def subscribe(
+        self,
+        callback: CB[MT],
+        *,
+        decoder: Optional[Callable[[bytes], MT]] = None,
+        offset: Optional[int] = None,
+        offset_type: OffsetType = OffsetType.FIRST,
+        initial_credit: int = 10,
+        properties: Optional[dict[str, Any]] = None,
+        subscriber_name: Optional[str] = None,
+    ):
+
+        self._super_stream_metadata = DefaultSuperstreamMetadata(self.super_stream, self.default_client)
+        partitions = await self._super_stream_metadata.partitions()
+
+        for partition in partitions:
+            if partition not in self._consumers.keys():
+                consumer = await self._create_consumer()
+                self._consumers[partition] = consumer
+
+            consumer_partition: Optional[Consumer] = self._consumers.get(partition)
+            if consumer_partition is None:
+                return
+
+            subscriber = await consumer_partition.subscribe(
+                stream=partition,
+                callback=callback,
+                decoder=decoder,
+                offset_type=offset_type,
+                offset=offset,
+                initial_credit=initial_credit,
+                properties=properties,
+                subscriber_name=subscriber_name,
+            )
+            self._subscribers[partition] = subscriber
+
+    async def _create_consumer(self) -> Consumer:
+        consumer = Consumer(
+            host=self.host,
+            port=self.port,
+            vhost=self.vhost,
+            username=self.username,
+            password=self.password,
+            ssl_context=self.ssl_context,
+            frame_max=self.frame_max,
+            heartbeat=self.heartbeat,
+            load_balancer_mode=False,
+            max_retries=self.max_retries,
+        )
+
+        await consumer.start()
+
+        return consumer
+
+    async def unsubscribe(self) -> None:
+
+        partitions = await self._super_stream_metadata.partitions()
+        for partition in partitions:
+            if self._consumers[partition] is None:
+                self._consumers[partition] = await self._create_consumer()
+
+            consumer = self._consumers[partition]
+            await consumer.unsubscribe(self._subscribers[partition])

--- a/rstream/superstream_producer.py
+++ b/rstream/superstream_producer.py
@@ -1,0 +1,140 @@
+# Copyright 2023 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: MIT
+
+import ssl
+from enum import Enum
+from typing import (
+    Annotated,
+    Any,
+    Awaitable,
+    Callable,
+    Optional,
+    TypeVar,
+)
+
+from .amqp import _MessageProtocol
+from .client import Client, ClientPool
+from .producer import ConfirmationStatus, Producer
+from .superstream import (
+    DefaultSuperstreamMetadata,
+    HashRoutingMurmurStrategy,
+    RoutingKeyRoutingStrategy,
+    RoutingStrategy,
+)
+
+MT = TypeVar("MT")
+CB = Annotated[Callable[[MT], Awaitable[Any]], "Message callback type"]
+
+MessageT = TypeVar("MessageT", _MessageProtocol, bytes)
+
+
+class RouteType(Enum):
+    Hash = 0
+    Key = 1
+
+
+class SuperStreamProducer:
+    def __init__(
+        self,
+        host: str,
+        port: int = 5552,
+        *,
+        ssl_context: Optional[ssl.SSLContext] = None,
+        vhost: str = "/",
+        username: str,
+        password: str,
+        super_stream: str,
+        routing_extractor: CB[Any],
+        routing: RouteType = RouteType.Hash,
+        frame_max: int = 1 * 1024 * 1024,
+        heartbeat: int = 60,
+        load_balancer_mode: bool = False,
+        max_retries: int = 20,
+        default_batch_publishing_delay: float = 0.2,
+    ):
+        self._pool = ClientPool(
+            host,
+            port,
+            ssl_context=ssl_context,
+            vhost=vhost,
+            username=username,
+            password=password,
+            frame_max=frame_max,
+            heartbeat=heartbeat,
+            load_balancer_mode=load_balancer_mode,
+            max_retries=max_retries,
+        )
+        self.host = host
+        self.port = port
+        self.vhost = vhost
+        self.username = username
+        self.password = password
+        self.ssl_context = ssl_context
+        self.super_stream = super_stream
+        self.routing = routing
+        self.routing_extractor: CB[Any] = routing_extractor
+        self.frame_max = frame_max
+        self.heartbeat = heartbeat
+        self.load_balancer_mode = load_balancer_mode
+        self.max_retries = max_retries
+        self.default_batch_publishing_delay = default_batch_publishing_delay
+        self._default_client: Optional[Client] = None
+        self._producer: Producer | None = None
+        self._routing_strategy: RoutingStrategy
+
+    async def _get_producer(self) -> Producer:
+        if self._producer is None:
+            producer = Producer(
+                host=self.host,
+                port=self.port,
+                vhost=self.vhost,
+                username=self.username,
+                password=self.password,
+                ssl_context=self.ssl_context,
+                frame_max=self.frame_max,
+                heartbeat=self.heartbeat,
+                load_balancer_mode=self.load_balancer_mode,
+                default_batch_publishing_delay=self.default_batch_publishing_delay,
+            )
+            await producer.start()
+            self._producer = producer
+        return self._producer
+
+    async def send(
+        self,
+        message: MessageT,
+        on_publish_confirm: Optional[CB[ConfirmationStatus]] = None,
+    ) -> None:
+
+        streams = await self._routing_strategy.route(message, self.super_stream_metadata)
+        self._producer = await self._get_producer()
+
+        for stream in streams:
+            await self._producer.send(stream=stream, message=message, on_publish_confirm=on_publish_confirm)
+
+    @property
+    def default_client(self) -> Client:
+        if self._default_client is None:
+            raise ValueError("Producer is not started")
+        return self._default_client
+
+    async def __aenter__(self):
+        await self.start()
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        await self.close()
+
+    async def start(self) -> None:
+        self._default_client = await self._pool.get()
+        self.super_stream_metadata = DefaultSuperstreamMetadata(self.super_stream, self._default_client)
+        if self.routing == RouteType.Hash:
+            self._routing_strategy = HashRoutingMurmurStrategy(self.routing_extractor)
+        else:
+            self._routing_strategy = RoutingKeyRoutingStrategy(self.routing_extractor)
+
+    async def close(self) -> None:
+        await self._pool.close()
+        if self._producer is not None:
+            await self._producer.close()
+        self._default_client = None

--- a/tests/util.py
+++ b/tests/util.py
@@ -38,3 +38,7 @@ def on_publish_confirm_client_callback2(
 
 async def routing_extractor(message: AMQPMessage) -> str:
     return "0"
+
+
+async def routing_extractor_key(message: AMQPMessage) -> str:
+    return "key1"


### PR DESCRIPTION
Implementing the consumer side of super-stream with the tests


This PR implements consumer side logic for super-stream (https://github.com/qweeze/rstream/issues/58)
We are not implementing an auto-reconnect logic, and single-active-consumer functionality will be implemented on a different PR.
