### PR TITLE
manual offset implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,11 @@ async def consume():
     loop.add_signal_handler(signal.SIGINT, lambda: asyncio.create_task(consumer.close()))
 
     def on_message(msg: AMQPMessage, message_context: MessageContext):
-        print('Got message: {}'.format(msg) + "from stream " + message_context.stream+ "offset: " + str(message_context.offset))
+        consumer = message_context.consumer
+        stream = await message_context.consumer.stream(message_context.subscriber_name)
+        offset = message_context.offset
+    
+    print('Got message: {}'.format(msg) + "from stream " + stream+ "offset: " + str(offset))
 
     await consumer.start()
     await consumer.subscribe('mystream', on_message, decoder=amqp_decoder)
@@ -182,6 +186,82 @@ async def consume():
 
 asyncio.run(consume())
 ```
+
+### Server-side offset tracking
+
+RabbitMQ Streams provides server-side offset tracking for consumers. This features allows a consuming application to restart consuming where it left off in a previous run.
+You can use the store_offset (to store an offset in the server) and query_offset (to query it) methods of the consumer class like in this example:
+
+```python
+cont = 0
+lock = asyncio.Lock()
+
+async def on_message(msg: AMQPMessage, message_context: MessageContext):
+
+    global cont
+    global lock
+
+    consumer = message_context.consumer
+    stream = await message_context.consumer.stream(message_context.subscriber_name)
+    offset = message_context.offset
+    
+    print('Got message: {}'.format(msg) + "from stream " + stream+ "offset: " + str(offset))
+
+    # store the offset every 1000 messages received
+    async with lock:
+        cont = cont+1
+        # store the offset every 1000 messages received
+        if (cont % 1000 == 0):
+            await consumer.store_offset(stream=stream, offset=offset, subscriber_name=message_context.subscriber_name)
+
+async def consume():
+
+    consumer = Consumer  (
+    host='localhost',
+    port=5552,
+        vhost='/',
+        username='guest',
+        password='guest',
+    )
+
+    loop = asyncio.get_event_loop()
+    loop.add_signal_handler(signal.SIGINT, lambda: asyncio.create_task(consumer.close()))
+
+    await consumer.start()
+    # Take back the server stored offset
+    try: 
+        my_offset = await consumer.query_offset(stream="mixing", subscriber_name="subscriber_1")
+    # catch exceptions if stream or offset for the subscriber name doesn't exist
+    except OffsetNotFound as offset_exception:
+        print(f"ValueError: {offset_exception}")
+        exit(1)
+    
+    except StreamDoesNotExist as stream_exception:
+        print(f"ValueError: {stream_exception}")
+        exit(1)
+         
+    except ServerError as e:
+        print(f"ValueError: {e}")
+        exit(1)
+   
+    await consumer.subscribe(stream='mixing', subscriber_name='subscriber-1', callback=on_message, decoder=amqp_decoder, offset_type=OffsetType.OFFSET, offset=my_offset)
+    await consumer.run()
+
+# main coroutine
+async def main():
+    # schedule the task
+    task = asyncio.create_task(consume())
+
+    # wait a moment
+    await asyncio.sleep(5)
+    # cancel the task
+    was_cancelled = task.cancel()
+ 
+# run the asyncio program
+asyncio.run(main())
+```
+
+
 
 ### Superstreams
 

--- a/docs/examples/manual_server_offset_tracking/consumer.py
+++ b/docs/examples/manual_server_offset_tracking/consumer.py
@@ -1,0 +1,96 @@
+import asyncio
+import signal
+from typing import Optional
+
+from rstream import (
+    AMQPMessage,
+    Consumer,
+    MessageContext,
+    OffsetNotFound,
+    OffsetType,
+    ServerError,
+    StreamDoesNotExist,
+    amqp_decoder,
+)
+
+cont = 0
+lock = asyncio.Lock()
+
+
+async def on_message(msg: AMQPMessage, message_context: MessageContext):
+    global cont
+    global lock
+
+    consumer = message_context.consumer
+    stream = await message_context.consumer.stream(message_context.subscriber_name)
+    offset = message_context.offset
+
+    print("Got message: {}".format(msg) + "from stream " + stream + "offset: " + str(offset))
+
+    # store the offset every 1000 messages received
+    async with lock:
+        cont = cont + 1
+        # store the offset every 1000 messages received
+        if cont % 1000 == 0:
+            await consumer.store_offset(
+                stream=stream, offset=offset, subscriber_name=message_context.subscriber_name
+            )
+
+
+async def consume():
+
+    consumer = Consumer(
+        host="localhost",
+        port=5552,
+        vhost="/",
+        username="guest",
+        password="guest",
+    )
+
+    loop = asyncio.get_event_loop()
+    loop.add_signal_handler(signal.SIGINT, lambda: asyncio.create_task(consumer.close()))
+
+    await consumer.start()
+    # catch exceptions if stream or offset for the subscriber name doesn't exist
+    try:
+        my_offset = await consumer.query_offset(stream="mixing", subscriber_name="subscriber_1")
+    except OffsetNotFound as offset_exception:
+        print(f"ValueError: {offset_exception}")
+        exit(1)
+
+    except StreamDoesNotExist as stream_exception:
+        print(f"ValueError: {stream_exception}")
+        exit(1)
+
+    except ServerError as e:
+        print(f"ValueError: {e}")
+        exit(1)
+
+    # print("offset is" + str(my_offset))
+    await consumer.subscribe(
+        stream="mixing",
+        subscriber_name="subscriber_1",
+        callback=on_message,
+        decoder=amqp_decoder,
+        offset_type=OffsetType.OFFSET,
+        offset=my_offset,
+    )
+    await consumer.run()
+
+
+# main coroutine
+async def main():
+    # schedule the task
+    task = asyncio.create_task(consume())
+    # suspend a moment
+    # wait a moment
+    await asyncio.sleep(5)
+    # cancel the task
+    was_cancelled = task.cancel()
+
+    # report a message
+    print("Main done")
+
+
+# run the asyncio program
+asyncio.run(main())

--- a/docs/examples/super_stream/super_stream_consumer.py
+++ b/docs/examples/super_stream/super_stream_consumer.py
@@ -13,12 +13,10 @@ from rstream import (
 cont = 0
 
 
-def on_message(msg: AMQPMessage, message_context: MessageContext):
-    print(
-        "Received message: {} from stream: {} - message offset: {}".format(
-            msg, message_context.stream, message_context.offset
-        )
-    )
+async def on_message(msg: AMQPMessage, message_context: MessageContext):
+    stream = await message_context.consumer.stream(message_context.subscriber_name)
+    offset = message_context.offset
+    print("Received message: {} from stream: {} - message offset: {}".format(msg, stream, offset))
 
 
 async def consume():

--- a/rstream/__init__.py
+++ b/rstream/__init__.py
@@ -16,6 +16,9 @@ from .amqp import AMQPMessage, amqp_decoder  # noqa: E402
 from .compression import CompressionType  # noqa: E402
 from .constants import OffsetType  # noqa: E402
 from .consumer import Consumer, MessageContext  # noqa: E402
+from .exceptions import OffsetNotFound  # noqa: E402
+from .exceptions import ServerError  # noqa: E402
+from .exceptions import StreamDoesNotExist  # noqa: E402
 from .producer import (  # noqa: E402
     ConfirmationStatus,
     Producer,
@@ -42,4 +45,7 @@ __all__ = [
     "RouteType",
     "SuperStreamConsumer",
     "MessageContext",
+    "ServerError",
+    "OffsetNotFound",
+    "StreamDoesNotExist",
 ]

--- a/tests/util.py
+++ b/tests/util.py
@@ -3,7 +3,11 @@
 
 import asyncio
 
-from rstream import AMQPMessage, ConfirmationStatus
+from rstream import (
+    AMQPMessage,
+    ConfirmationStatus,
+    MessageContext,
+)
 
 captured: list[bytes] = []
 
@@ -42,3 +46,13 @@ async def routing_extractor(message: AMQPMessage) -> str:
 
 async def routing_extractor_key(message: AMQPMessage) -> str:
     return "key1"
+
+
+async def on_message(
+    msg: AMQPMessage, message_context: MessageContext, streams: list[str], offsets: list[int]
+):
+
+    stream = await message_context.consumer.stream(message_context.subscriber_name)
+    streams.append(stream)
+    offset = message_context.offset
+    offsets.append(offset)


### PR DESCRIPTION
This PR allows a user to manage server-side offsets storing and tracking:

https://blog.rabbitmq.com/posts/2021/09/rabbitmq-streams-offset-tracking/

It exposes store_offset and query_offset to the consumer callback through the consumer object so that an user can store the offset after consuming messages (for example every 1000 messages consumed).

It also adds tests.