### PR TITLE
adding consumer as async task

### DIFF
--- a/rstream/superstream_consumer.py
+++ b/rstream/superstream_consumer.py
@@ -159,6 +159,8 @@ class SuperStreamConsumer:
             )
             self._subscribers[partition] = subscriber
 
+            asyncio.create_task(consumer_partition.run())
+
     async def _create_consumer(self) -> Consumer:
         consumer = Consumer(
             host=self.host,


### PR DESCRIPTION
This will close (hopefully) https://github.com/qweeze/rstream/issues/102

consumers in superstream are run as async task