### PR TITLE
fixing publish confirmation for send_batch

### DIFF
--- a/docs/examples/producers_with_confirmations/send_batch_with_confirmation.py
+++ b/docs/examples/producers_with_confirmations/send_batch_with_confirmation.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 
 from rstream import (
     AMQPMessage,
@@ -27,7 +28,7 @@ async def publish():
     async with Producer("localhost", username="guest", password="guest") as producer:
         # create a stream if it doesn't already exist
         await producer.create_stream(STREAM, exists_ok=True)
-
+        start_time = time.perf_counter()
         # sending a million of messages in AMQP format
         for j in range(LOOP):
             messages = []
@@ -40,6 +41,12 @@ async def publish():
             await producer.send_batch(
                 stream=STREAM, batch=messages, on_publish_confirm=_on_publish_confirm_client
             )
+
+            if (j % 1000) == 0:
+                print(f"Sent {j * BATCH} messages in {time.perf_counter() - start_time:0.4f} seconds")
+
+        end_time = time.perf_counter()
+        print(f"Sent {LOOP * BATCH} messages in {end_time - start_time:0.4f} seconds")
 
         # callbacks live in the same scope of Producer so we need to wait till the messages have been confirmed
         # before exiting Producer scope

--- a/docs/examples/producers_with_confirmations/send_with_confirmation.py
+++ b/docs/examples/producers_with_confirmations/send_with_confirmation.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 
 from rstream import (
     AMQPMessage,
@@ -26,6 +27,7 @@ async def publish():
     async with Producer("localhost", username="guest", password="guest") as producer:
         # create a stream if it doesn't already exist
         await producer.create_stream(STREAM, exists_ok=True)
+        start_time = time.perf_counter()
 
         # sending a million of messages in AMQP format
         for i in range(MESSAGES):
@@ -37,6 +39,12 @@ async def publish():
             await producer.send(
                 stream=STREAM, message=amqp_message, on_publish_confirm=_on_publish_confirm_client
             )
+
+            if (i % 10000) == 0:
+                print(f"Sent {i} messages in {time.perf_counter() - start_time:0.4f} seconds")
+
+        end_time = time.perf_counter()
+        print(f"Sent {MESSAGES} messages in {end_time - start_time:0.4f} seconds")
 
         # callbacks live in the same scope of Producer so we need to wait till the messages have been confirmed
         # before exiting Producer scope

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rstream"
-version = "0.11.0"
+version = "0.11.1"
 description = "A python client for RabbitMQ Streams"
 authors = ["George Fortunatov <qweeeze@gmail.com>", "Daniele Palaia <dpalaia@vmware.com>"]
 readme = "README.md"


### PR DESCRIPTION
This closes https://github.com/qweeze/rstream/issues/90

There was a bug in the _send_batch as just the last batch was set to confirm ignoring all the others.