### PR TITLE
treat all handle callbacks as asyncio tasks

### DIFF
--- a/docs/examples/check_connection_broken/consumer_handle_connections_issues.py
+++ b/docs/examples/check_connection_broken/consumer_handle_connections_issues.py
@@ -11,7 +11,7 @@ from rstream import (
 STREAM = "my-test-stream"
 
 
-def on_connection_closed(reason: Exception) -> None:
+async def on_connection_closed(reason: Exception) -> None:
     print("connection has been closed for reason: " + str(reason))
 
 

--- a/docs/examples/check_connection_broken/producer_handle_connections_issues.py
+++ b/docs/examples/check_connection_broken/producer_handle_connections_issues.py
@@ -7,7 +7,7 @@ STREAM = "my-test-stream"
 MESSAGES = 1000000
 
 
-def on_connection_closed(reason: Exception) -> None:
+async def on_connection_closed(reason: Exception) -> None:
     print("connection has been closed for reason: " + str(reason))
 
 

--- a/docs/examples/producers_with_confirmations/send_batch_with_confirmation.py
+++ b/docs/examples/producers_with_confirmations/send_batch_with_confirmation.py
@@ -12,7 +12,7 @@ LOOP = 10_000
 BATCH = 100
 
 
-def _on_publish_confirm_client(confirmation: ConfirmationStatus) -> None:
+async def _on_publish_confirm_client(confirmation: ConfirmationStatus) -> None:
     if confirmation.is_confirmed:
         if (confirmation.message_id % 5000) == 0:
             print("message id: {} is confirmed".format(confirmation.message_id))

--- a/docs/examples/producers_with_confirmations/send_with_confirmation.py
+++ b/docs/examples/producers_with_confirmations/send_with_confirmation.py
@@ -11,7 +11,7 @@ STREAM = "my-test-stream"
 MESSAGES = 1_000_000
 
 
-def _on_publish_confirm_client(confirmation: ConfirmationStatus) -> None:
+async def _on_publish_confirm_client(confirmation: ConfirmationStatus) -> None:
     if confirmation.is_confirmed:
         if (confirmation.message_id % 5000) == 0:
             print("message id: {} is confirmed".format(confirmation.message_id))

--- a/rstream/client.py
+++ b/rstream/client.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import socket
 import ssl
@@ -139,7 +140,9 @@ class BaseClient:
             if self._connection_closed_handler is None:
                 print("TCP connection closed")
             else:
-                self._connection_closed_handler(e)
+                result = self._connection_closed_handler(e)
+                if result is not None and inspect.isawaitable(result):
+                    await result
 
     def wait_frame(
         self,
@@ -179,13 +182,17 @@ class BaseClient:
                 frame = await self._conn.read_frame()
             except ConnectionClosed as e:
                 if self._connection_closed_handler is not None:
-                    self._connection_closed_handler(e)
+                    result = self._connection_closed_handler(e)
+                    if result is not None and inspect.isawaitable(result):
+                        await result
                 else:
                     print("TCP connection closed")
                 break
             except socket.error as e:
                 if self._connection_closed_handler is not None:
-                    self._connection_closed_handler(e)
+                    result = self._connection_closed_handler(e)
+                    if result is not None and inspect.isawaitable(result):
+                        await result
                 else:
                     print("TCP connection closed")
                 break

--- a/tests/util.py
+++ b/tests/util.py
@@ -42,7 +42,7 @@ async def wait_for(condition, timeout=1):
     await asyncio.wait_for(_wait(), timeout)
 
 
-def on_publish_confirm_client_callback(
+async def on_publish_confirm_client_callback(
     confirmation: ConfirmationStatus, confirmed_messages: list[int], errored_messages: list[int]
 ) -> None:
 
@@ -52,7 +52,7 @@ def on_publish_confirm_client_callback(
         errored_messages.append(confirmation.message_id)
 
 
-def on_publish_confirm_client_callback2(
+async def on_publish_confirm_client_callback2(
     confirmation: ConfirmationStatus, confirmed_messages: list[int], errored_messages: list[int]
 ) -> None:
 


### PR DESCRIPTION
It is better to consider all confirmation handlers as asynchronous tasks.

Some few tests around performance are needed