### PR TITLE
Improve callback handlers

### DIFF
--- a/rstream/client.py
+++ b/rstream/client.py
@@ -206,9 +206,9 @@ class BaseClient:
 
             for _, handler in self._handlers.get(frame.__class__, {}).items():
                 try:
-                    maybe_coro = handler(frame)
-                    if maybe_coro is not None:
-                        await maybe_coro
+                    asyncio.create_task(handler(frame))
+                    #if maybe_coro is not None:
+                    #    await maybe_coro
                 except Exception:
                     logger.exception("Error while running handler %s of frame %s", handler, frame)
 

--- a/rstream/client.py
+++ b/rstream/client.py
@@ -187,14 +187,14 @@ class BaseClient:
     async def _run_delivery_handlers(self):
 
         while True:
+            frame_entry = None
             try:
                 frame_entry = await self._frames.get()
-                maybe_coro = await frame_entry.handler(frame_entry.frame)
+                maybe_coro = frame_entry.handler(frame_entry.frame)
                 if maybe_coro is not None:
                     await maybe_coro
-            except Exception as e:
-                logger.debug("Error reading item from _run_delivery_handlers: " + str(e))
-                break
+            except Exception:
+                logger.exception("Error while handling %s frame " + str(frame_entry.frame.__class__))
 
     async def _listener(self) -> None:
         assert self._conn

--- a/rstream/consumer.py
+++ b/rstream/consumer.py
@@ -192,6 +192,8 @@ class Consumer:
                 offset=offset_specification.offset,
             )
 
+            await subscriber.client.run_queue_listener_task(subscriber_name=subscriber.reference)
+
         subscriber.client.add_handler(
             schema.Deliver,
             partial(self._on_deliver, subscriber=subscriber),

--- a/rstream/consumer.py
+++ b/rstream/consumer.py
@@ -192,7 +192,9 @@ class Consumer:
                 offset=offset_specification.offset,
             )
 
-            await subscriber.client.run_queue_listener_task(subscriber_name=subscriber.reference)
+            await subscriber.client.run_queue_listener_task(
+                subscriber_name=subscriber.reference, handler=partial(self._on_deliver, subscriber=subscriber)
+            )
 
         subscriber.client.add_handler(
             schema.Deliver,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,6 +108,24 @@ async def consumer(pytestconfig, ssl_context):
 
 
 @pytest.fixture()
+async def test_consumer_close(pytestconfig, ssl_context):
+    consumer = Consumer(
+        host=pytestconfig.getoption("rmq_host"),
+        port=pytestconfig.getoption("rmq_port"),
+        ssl_context=ssl_context,
+        username=pytestconfig.getoption("rmq_username"),
+        password=pytestconfig.getoption("rmq_password"),
+        frame_max=1024 * 1024,
+        heartbeat=60,
+    )
+    await consumer.start()
+    try:
+        yield consumer
+    finally:
+        await consumer.close()
+
+
+@pytest.fixture()
 async def producer(pytestconfig, ssl_context):
     producer = Producer(
         host=pytestconfig.getoption("rmq_host"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,24 +108,6 @@ async def consumer(pytestconfig, ssl_context):
 
 
 @pytest.fixture()
-async def test_consumer_close(pytestconfig, ssl_context):
-    consumer = Consumer(
-        host=pytestconfig.getoption("rmq_host"),
-        port=pytestconfig.getoption("rmq_port"),
-        ssl_context=ssl_context,
-        username=pytestconfig.getoption("rmq_username"),
-        password=pytestconfig.getoption("rmq_password"),
-        frame_max=1024 * 1024,
-        heartbeat=60,
-    )
-    await consumer.start()
-    try:
-        yield consumer
-    finally:
-        await consumer.close()
-
-
-@pytest.fixture()
 async def producer(pytestconfig, ssl_context):
     producer = Producer(
         host=pytestconfig.getoption("rmq_host"),

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -502,3 +502,17 @@ async def test_consume_superstream_with_callback_offset(
     consumers_set = consumers_set.union(consumer_stream_list3)
 
     assert len(consumers_set) == 3
+
+
+async def test_callback_sync_request(stream: str, test_consumer_close: Consumer, producer: Producer) -> None:
+    captured: list[bytes] = []
+
+    async def on_message_first(msg: AMQPMessage, message_context: MessageContext):
+        captured.append(bytes(msg))
+        await test_consumer_close.close()
+
+    await test_consumer_close.subscribe(stream, callback=on_message_first)
+    messages = [str(i).encode() for i in range(0, 1)]
+    await producer.send_batch(stream, messages)
+
+    await wait_for(lambda: len(captured) >= 1)

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -504,14 +504,14 @@ async def test_consume_superstream_with_callback_offset(
     assert len(consumers_set) == 3
 
 
-async def test_callback_sync_request(stream: str, test_consumer_close: Consumer, producer: Producer) -> None:
+async def test_callback_sync_request(stream: str, consumer: Consumer, producer: Producer) -> None:
     captured: list[bytes] = []
 
     async def on_message_first(msg: AMQPMessage, message_context: MessageContext):
         captured.append(bytes(msg))
-        await test_consumer_close.close()
+        await consumer.close()
 
-    await test_consumer_close.subscribe(stream, callback=on_message_first)
+    await consumer.subscribe(stream, callback=on_message_first)
     messages = [str(i).encode() for i in range(0, 1)]
     await producer.send_batch(stream, messages)
 


### PR DESCRIPTION
This closes: https://github.com/qweeze/rstream/issues/126 
This closes: https://github.com/qweeze/rstream/issues/123

This PR is running the delivery callback of the consumer in a different thread in order to let the listener unblocked to receive new frame.

It allows the defined consumer callback to be able to do synchronous requests like in the unit test

