### PR TITLE
Reconnect streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,8 @@ connection_closed_handler=on_connection_closed,
 )
 ```
 
+After the event is raised you can decide to close the Consumers/Poducers doing a correct clean-up or try to reconnect 
+using reconnect_stream.
 Please take a look at the complete examples [here](https://github.com/qweeze/rstream/blob/master/docs/examples/check_connection_broken/)
 
 ## Load Balancer

--- a/docs/examples/basic_consumers/README.md
+++ b/docs/examples/basic_consumers/README.md
@@ -11,8 +11,5 @@ The subscribe method of consumer will take in input a callback (on_message) that
 MessageContext store some info about the message (the stream, and the current offset)
 
 Possible values of OffsetType are: FIRST (default), NEXT, LAST, TIMESTAMP and OFFSET
-<<<<<<< HEAD
-=======
 
 Is it also possible to store offsets server-side (see manual_server_offset_tracking folder for an example on this)
->>>>>>> 55778554d17244679f955868c2f02b07514c7352

--- a/docs/examples/check_connection_broken/README.md
+++ b/docs/examples/check_connection_broken/README.md
@@ -1,16 +1,21 @@
 Connection broken
 ---
 
-The client does not support auto-reconnect at the moment.
+The client does not support auto-reconnect at the moment, but it allows you to be notified if such event happens 
+and take action through a callback. 
 
-But it allows you to be notified if such event happens and take action through a callback. 
-
-This callback can be passed to the constructor of (superstream)consumers/(superstream)producers
+This callback can be passed to the constructor of (superstream)consumers/(superstream)producers during instantiation.
 
 You can use these callbacks in order to notify your main flow that a disconnection happened to properly close 
 consumers and producers or you can use the method reconnect_stream in order to try to reconnect to the stream.
 
-You can find the example in this folder for close and reconnect.
+You can find the examples in this folder for the close and reconnect scenarios for both (superstream)producers and
+(superstream)consumers.
 
-Please note that if you don't specify this callback, just and exception will be raised.
+Please note that if you don't specify this callback, just a ConnectionClosed exception is raised.
+
+# Specify an offset to restart
+
+In case of a consumer or super_stream_consumer you can specify in the reconnect_stream method the offset you want to
+restart consuming. If you don't specify it by default it reconnects from the last consumed message.
 

--- a/docs/examples/check_connection_broken/README.md
+++ b/docs/examples/check_connection_broken/README.md
@@ -1,0 +1,16 @@
+Connection broken
+---
+
+The client does not support auto-reconnect at the moment.
+
+But it allows you to be notified if such event happens and take action through a callback. 
+
+This callback can be passed to the constructor of (superstream)consumers/(superstream)producers
+
+You can use these callbacks in order to notify your main flow that a disconnection happened to properly close 
+consumers and producers or you can use the method reconnect_stream in order to try to reconnect to the stream.
+
+You can find the example in this folder for close and reconnect.
+
+Please note that if you don't specify this callback, just and exception will be raised.
+

--- a/docs/examples/check_connection_broken/consumer_handle_connections_issues_with_reconnection.py
+++ b/docs/examples/check_connection_broken/consumer_handle_connections_issues_with_reconnection.py
@@ -12,7 +12,6 @@ from rstream import (
 STREAM = "my-test-stream"
 COUNT = 0
 connection_is_closed = False
-offset_to_restart = 0
 
 
 async def consume():
@@ -27,7 +26,9 @@ async def consume():
         global connection_is_closed
 
         for stream in disconnection_info.streams:
-            await consumer.reconnect_stream(stream, offset_to_restart)
+            # restart from last offset in subscriber
+            # alternatively you can specify an offset to reconnect
+            await consumer.reconnect_stream(stream)
 
     consumer = Consumer(
         host="localhost",

--- a/docs/examples/check_connection_broken/consumer_handle_connections_issues_with_reconnection.py
+++ b/docs/examples/check_connection_broken/consumer_handle_connections_issues_with_reconnection.py
@@ -1,0 +1,60 @@
+import asyncio
+import signal
+
+from rstream import (
+    AMQPMessage,
+    Consumer,
+    DisconnectionErrorInfo,
+    MessageContext,
+    amqp_decoder,
+)
+
+STREAM = "my-test-stream"
+COUNT = 0
+connection_is_closed = False
+offset_to_restart = 0
+
+
+async def consume():
+    async def on_connection_closed(disconnection_info: DisconnectionErrorInfo) -> None:
+        print(
+            "connection has been closed from stream: "
+            + str(disconnection_info.streams)
+            + " for reason: "
+            + str(disconnection_info.reason)
+        )
+
+        global connection_is_closed
+
+        for stream in disconnection_info.streams:
+            await consumer.reconnect_stream(stream, offset_to_restart)
+
+    consumer = Consumer(
+        host="localhost",
+        port=5552,
+        vhost="/",
+        username="guest",
+        password="guest",
+        connection_closed_handler=on_connection_closed,
+    )
+
+    loop = asyncio.get_event_loop()
+    loop.add_signal_handler(signal.SIGINT, lambda: asyncio.create_task(consumer.close()))
+
+    async def on_message(msg: AMQPMessage, message_context: MessageContext):
+        stream = message_context.consumer.get_stream(message_context.subscriber_name)
+        offset = message_context.offset
+        global COUNT
+        COUNT = COUNT + 1
+        if COUNT % 1000000 == 0:
+            # print("Got message: {} from stream {}, offset {}".format(msg, stream, offset))
+            print("consumed 1 million messages")
+
+    await consumer.start()
+    await consumer.subscribe(
+        stream=STREAM, callback=on_message, decoder=amqp_decoder, subscriber_name="subscriber_1"
+    )
+    await consumer.run()
+
+
+asyncio.run(consume())

--- a/docs/examples/check_connection_broken/superstream_consumer_handle_reconnection.py
+++ b/docs/examples/check_connection_broken/superstream_consumer_handle_reconnection.py
@@ -1,0 +1,60 @@
+import asyncio
+import signal
+
+from rstream import (
+    AMQPMessage,
+    ConsumerOffsetSpecification,
+    DisconnectionErrorInfo,
+    MessageContext,
+    OffsetType,
+    SuperStreamConsumer,
+    amqp_decoder,
+)
+
+count = 0
+connection_is_closed = False
+offset_to_restart = 10
+
+
+async def on_message(msg: AMQPMessage, message_context: MessageContext):
+    global count
+    count += 1
+    if (count % 100000) == 0:
+        stream = await message_context.consumer.stream(message_context.subscriber_name)
+        offset = message_context.offset
+        print("Received message: {} from stream: {} - message offset: {}".format(msg, stream, offset))
+
+
+async def consume():
+    async def on_connection_closed(disconnection_info: DisconnectionErrorInfo) -> None:
+        print(
+            "connection has been closed from stream: "
+            + str(disconnection_info.streams)
+            + " for reason: "
+            + disconnection_info.reason
+        )
+
+        for stream in disconnection_info.streams:
+            await consumer.reconnect_stream(stream, offset_to_restart)
+
+    consumer = SuperStreamConsumer(
+        host="localhost",
+        port=5552,
+        vhost="/",
+        username="guest",
+        password="guest",
+        super_stream="invoices",
+        connection_closed_handler=on_connection_closed,
+    )
+
+    loop = asyncio.get_event_loop()
+    loop.add_signal_handler(signal.SIGINT, lambda: asyncio.create_task(consumer.close()))
+    offset_specification = ConsumerOffsetSpecification(OffsetType.FIRST, None)
+    await consumer.start()
+    await consumer.subscribe(
+        callback=on_message, decoder=amqp_decoder, offset_specification=offset_specification
+    )
+    await consumer.run()
+
+
+asyncio.run(consume())

--- a/docs/examples/check_connection_broken/superstream_consumer_handle_reconnection.py
+++ b/docs/examples/check_connection_broken/superstream_consumer_handle_reconnection.py
@@ -13,7 +13,6 @@ from rstream import (
 
 count = 0
 connection_is_closed = False
-offset_to_restart = 10
 
 
 async def on_message(msg: AMQPMessage, message_context: MessageContext):
@@ -35,7 +34,9 @@ async def consume():
         )
 
         for stream in disconnection_info.streams:
-            await consumer.reconnect_stream(stream, offset_to_restart)
+            # restart from last offset in subscriber
+            # alternatively you can specify an offset to reconnect
+            await consumer.reconnect_stream(stream)
 
     consumer = SuperStreamConsumer(
         host="localhost",

--- a/docs/examples/check_connection_broken/superstream_producer_handle_reconnection.py
+++ b/docs/examples/check_connection_broken/superstream_producer_handle_reconnection.py
@@ -1,0 +1,74 @@
+import asyncio
+import time
+
+from rstream import (
+    AMQPMessage,
+    DisconnectionErrorInfo,
+    RouteType,
+    SuperStreamProducer,
+)
+
+SUPER_STREAM = "invoices"
+MESSAGES = 10000000
+
+connection_is_closed = False
+
+
+async def publish():
+    # this value will be hashed using mumh3 hashing algorithm to decide the partition resolution for the message
+    async def routing_extractor(message: AMQPMessage) -> str:
+        return message.application_properties["id"]
+
+    async def on_connection_closed(disconnection_info: DisconnectionErrorInfo) -> None:
+
+        print(
+            "connection has been closed from stream: "
+            + str(disconnection_info.streams)
+            + " for reason: "
+            + disconnection_info.reason
+        )
+
+        for stream in disconnection_info.streams:
+            print("stream disconnected: " + stream)
+            await super_stream_producer.reconnect_stream(stream)
+
+    # super_stream_producer will be closed by the async context manager
+    # both if connection is still alive or not
+    print("creating super_stream producer")
+    async with SuperStreamProducer(
+        "localhost",
+        username="guest",
+        password="guest",
+        routing_extractor=routing_extractor,
+        routing=RouteType.Hash,
+        connection_closed_handler=on_connection_closed,
+        super_stream=SUPER_STREAM,
+    ) as super_stream_producer:
+
+        # sending a million of messages in AMQP format
+        start_time = time.perf_counter()
+        global connection_is_closed
+
+        print("sending messages")
+        for i in range(MESSAGES):
+            amqp_message = AMQPMessage(
+                body="hello: {}".format(i),
+                application_properties={"id": "{}".format(i)},
+            )
+
+            # send is asynchronous
+            try:
+                await super_stream_producer.send(message=amqp_message)
+            except:
+                # wait for reconnection to happen
+                await asyncio.sleep(2)
+                continue
+
+            if i % 10000 == 0:
+                print("sent 10000 MESSAGES")
+
+    end_time = time.perf_counter()
+    print(f"Sent {MESSAGES} messages in {end_time - start_time:0.4f} seconds")
+
+
+asyncio.run(publish())

--- a/rstream/client.py
+++ b/rstream/client.py
@@ -629,7 +629,7 @@ class ClientPool:
         """
         desired_addr = addr or self.addr
 
-        if desired_addr not in self._clients:
+        if desired_addr not in self._clients or self._clients[desired_addr].is_connection_alive() is False:
             if addr and self.load_balancer_mode:
                 self._clients[desired_addr] = await self._resolve_broker(
                     addr=desired_addr,

--- a/rstream/consumer.py
+++ b/rstream/consumer.py
@@ -362,7 +362,7 @@ class Consumer:
             return ""
         return self._subscribers[subscriber_name].stream
 
-    async def reconnect_stream(self, stream: str, offset: int) -> None:
+    async def reconnect_stream(self, stream: str, offset: Optional[int] = None) -> None:
 
         curr_subscriber = None
         for subscriber_id in self._subscribers:
@@ -378,6 +378,10 @@ class Consumer:
             if self._default_client.is_connection_alive() is False:
                 await self._default_client.close()
                 self._default_client = None
+
+        if offset is None:
+            if curr_subscriber is not None:
+                offset = curr_subscriber.offset
 
         offset_specification = ConsumerOffsetSpecification(OffsetType.OFFSET, offset)
         if curr_subscriber is not None:

--- a/rstream/consumer.py
+++ b/rstream/consumer.py
@@ -150,6 +150,7 @@ class Consumer:
                 addr=Addr(broker.host, broker.port),
                 connection_closed_handler=self._connection_closed_handler,
                 connection_name=self._connection_name,
+                stream=stream,
             )
 
         return self._clients[stream]

--- a/rstream/producer.py
+++ b/rstream/producer.py
@@ -188,6 +188,7 @@ class Producer:
                 connection_name=self._connection_name,
                 addr=Addr(leader.host, leader.port),
                 connection_closed_handler=self._connection_closed_handler,
+                stream=stream,
             )
 
         return self._clients[stream]
@@ -533,8 +534,9 @@ class Producer:
 
     async def check_connection(self):
 
-        if self._default_client.is_connection_alive() is False:
-            raise Exception("connection Closed")
+        for publisher in self._publishers.values():
+            if publisher.client.is_connection_alive() is False:
+                raise Exception("connection Closed")
 
     async def reconnect_stream(self, stream: str) -> None:
 

--- a/rstream/superstream.py
+++ b/rstream/superstream.py
@@ -44,6 +44,8 @@ class DefaultSuperstreamMetadata(Metadata):
                 raise ValueError(
                     "the number of partitions of the stream is <= to 0, the superstream doesn't probably exist"
                 )
+            # locator not necessary anymore
+            await self.client.close()
 
         return self._partitions
 

--- a/rstream/superstream_consumer.py
+++ b/rstream/superstream_consumer.py
@@ -123,6 +123,7 @@ class SuperStreamConsumer:
                 addr=Addr(broker.host, broker.port),
                 connection_closed_handler=self._connection_closed_handler,
                 connection_name=self._connection_name,
+                stream=stream,
             )
 
         return self._clients[stream]
@@ -185,7 +186,7 @@ class SuperStreamConsumer:
             ssl_context=self.ssl_context,
             frame_max=self.frame_max,
             heartbeat=self.heartbeat,
-            load_balancer_mode=False,
+            load_balancer_mode=self.load_balancer_mode,
             max_retries=self.max_retries,
             connection_closed_handler=self._connection_closed_handler,
             connection_name=self._connection_name,

--- a/rstream/superstream_consumer.py
+++ b/rstream/superstream_consumer.py
@@ -97,9 +97,7 @@ class SuperStreamConsumer:
         await self.close()
 
     async def start(self) -> None:
-        self._default_client = await self._pool.get(
-            connection_closed_handler=self._connection_closed_handler, connection_name="rstream-locator"
-        )
+        self._default_client = None
 
     def stop(self) -> None:
         self._stop_event.set()
@@ -147,6 +145,11 @@ class SuperStreamConsumer:
 
         if offset_specification is None:
             offset_specification = ConsumerOffsetSpecification(OffsetType.FIRST, None)
+
+        if self._default_client is None or self._default_client.is_connection_alive() is False:
+            self._default_client = await self._pool.get(
+                connection_closed_handler=self._connection_closed_handler, connection_name="rstream-locator"
+            )
 
         self._super_stream_metadata = DefaultSuperstreamMetadata(self.super_stream, self.default_client)
         partitions = await self._super_stream_metadata.partitions()

--- a/rstream/superstream_consumer.py
+++ b/rstream/superstream_consumer.py
@@ -129,6 +129,10 @@ class SuperStreamConsumer:
 
         return self._clients[stream]
 
+    async def get_consumer(self, partition: str):
+
+        return self._consumers[partition]
+
     async def subscribe(
         self,
         callback: Callable[[AMQPMessage, MessageContext], Union[None, Awaitable[None]]],
@@ -197,3 +201,6 @@ class SuperStreamConsumer:
 
             consumer = self._consumers[partition]
             await consumer.unsubscribe(self._subscribers[partition])
+
+    async def reconnect_stream(self, stream: str, offset: int) -> None:
+        await self._consumers[stream].reconnect_stream(stream, offset)

--- a/rstream/superstream_consumer.py
+++ b/rstream/superstream_consumer.py
@@ -205,5 +205,5 @@ class SuperStreamConsumer:
             consumer = self._consumers[partition]
             await consumer.unsubscribe(self._subscribers[partition])
 
-    async def reconnect_stream(self, stream: str, offset: int) -> None:
+    async def reconnect_stream(self, stream: str, offset: Optional[int] = None) -> None:
         await self._consumers[stream].reconnect_stream(stream, offset)

--- a/rstream/superstream_producer.py
+++ b/rstream/superstream_producer.py
@@ -155,4 +155,5 @@ class SuperStreamProducer:
     async def reconnect_stream(self, stream: str) -> None:
 
         # close previous clients and re-create a publisher (with a new client)
-        await self._producer.reconnect_stream(stream)
+        if self._producer is not None:
+            await self._producer.reconnect_stream(stream)

--- a/rstream/superstream_producer.py
+++ b/rstream/superstream_producer.py
@@ -151,3 +151,8 @@ class SuperStreamProducer:
         await self._pool.close()
         if self._producer is not None:
             await self._producer.close()
+
+    async def reconnect_stream(self, stream: str) -> None:
+
+        # close previous clients and re-create a publisher (with a new client)
+        await self._producer.reconnect_stream(stream)

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -3,7 +3,6 @@
 
 import asyncio
 import logging
-from collections import defaultdict
 from functools import partial
 
 import pytest

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import logging
+from collections import defaultdict
 from functools import partial
 
 import pytest
@@ -16,6 +17,7 @@ from rstream import (
     MessageContext,
     OffsetType,
     Producer,
+    RouteType,
     SuperStreamConsumer,
     SuperStreamProducer,
     amqp_decoder,
@@ -27,6 +29,7 @@ from .util import (
     consumer_update_handler_next,
     consumer_update_handler_offset,
     on_message,
+    routing_extractor_generic,
     run_consumer,
     task_to_delete_connection,
     wait_for,
@@ -598,6 +601,88 @@ async def test_super_stream_consumer_connection_broke(super_stream: str) -> None
 
     async def on_message(msg: AMQPMessage, message_context: MessageContext):
         message_context.consumer.get_stream(message_context.subscriber_name)
+
+    asyncio.create_task(task_to_delete_connection("test-connection"))
+
+    await super_stream_consumer_broke.start()
+    await super_stream_consumer_broke.subscribe(callback=on_message, decoder=amqp_decoder)
+    await super_stream_consumer_broke.run()
+
+    assert connection_broke is True
+    assert "test-super-stream-0" in streams_disconnected
+    assert "test-super-stream-1" in streams_disconnected
+    assert "test-super-stream-2" in streams_disconnected
+
+
+# Send a few messages to a superstream, consume, simulate a disconnection and check for reconnection
+# from offset 0
+async def test_super_stream_consumer_connection_broke_with_reconnect(super_stream: str) -> None:
+
+    connection_broke = False
+    streams_disconnected: set[str] = set()
+    consumer_broke: Consumer
+    offset_restart = 0
+
+    async def on_connection_closed(disconnection_info: DisconnectionErrorInfo) -> None:
+        logger.warning("connection closed")
+        nonlocal connection_broke
+        nonlocal streams_disconnected
+        # avoiding multiple connection closed to hit
+        if connection_broke is True:
+            for stream in disconnection_info.streams:
+                logger.warning("reconnecting")
+                streams_disconnected.add(stream)
+            return None
+
+        connection_broke = True
+
+        for stream in disconnection_info.streams:
+            streams_disconnected.add(stream)
+            # start from stored offset
+            await super_stream_consumer_broke.reconnect_stream(stream, offset_restart)
+
+    # Sending a few messages in the stream in order to be consumed
+    super_stream_producer_broke = SuperStreamProducer(
+        "localhost",
+        username="guest",
+        password="guest",
+        routing_extractor=routing_extractor_generic,
+        routing=RouteType.Hash,
+        connection_closed_handler=on_connection_closed,
+        connection_name="test-connection",
+        super_stream=super_stream,
+    )
+
+    await super_stream_producer_broke.start()
+
+    i = 0
+    for i in range(0, 10000):
+        amqp_message = AMQPMessage(
+            body="hello: {}".format(i),
+            application_properties={"id": "{}".format(i)},
+        )
+        await super_stream_producer_broke.send(message=amqp_message)
+
+    await super_stream_producer_broke.close()
+
+    super_stream_consumer_broke = SuperStreamConsumer(
+        host="localhost",
+        port=5552,
+        vhost="/",
+        username="guest",
+        password="guest",
+        connection_closed_handler=on_connection_closed,
+        connection_name="test-connection",
+        super_stream=super_stream,
+    )
+
+    async def on_message(msg: AMQPMessage, message_context: MessageContext):
+        nonlocal connection_broke
+        message_context.consumer.get_stream(message_context.subscriber_name)
+        # check after disconnection offset have been reset
+        if connection_broke is True:
+            assert message_context.offset == offset_restart
+            await super_stream_consumer_broke.close()
 
     asyncio.create_task(task_to_delete_connection("test-connection"))
 

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -482,7 +482,7 @@ async def test_producer_connection_broke(stream: str) -> None:
         try:
             await producer_broke.send(stream, b"one")
         # Connection broke
-        except:
+        except BaseException:
             break
 
     await producer_broke.close()
@@ -531,7 +531,7 @@ async def test_producer_connection_broke_with_send_batch(stream: str) -> None:
             else:
                 break
         # Connection closed
-        except:
+        except BaseException:
             break
 
     await producer_broke.close()
@@ -582,7 +582,7 @@ async def test_super_stream_producer_connection_broke(super_stream: str) -> None
             else:
                 break
         # Connection closed
-        except:
+        except BaseException:
             break
 
     await super_stream_producer_broke.close()
@@ -630,7 +630,7 @@ async def test_producer_connection_broke_with_reconnect(stream: str) -> None:
                 connection_broke = False
                 break
         # Connection broke wait for reconnection
-        except:
+        except BaseException:
             disconnected_once = True
             # wait for reconnection
             await asyncio.sleep(2)
@@ -688,7 +688,7 @@ async def test_super_stream_producer_connection_broke_with_reconnect(super_strea
                 connection_broke = False
                 break
             # Connection broke wait for reconnection
-        except:
+        except BaseException:
             disconnected_once = True
             # wait for reconnection
             await asyncio.sleep(2)

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -479,8 +479,11 @@ async def test_producer_connection_broke(stream: str) -> None:
     asyncio.create_task(task_to_delete_connection("test-connection"))
 
     while connection_broke is False:
-        await producer_broke.send(stream, b"one")
-        await asyncio.sleep(0)
+        try:
+            await producer_broke.send(stream, b"one")
+        # Connection broke
+        except:
+            break
 
     await producer_broke.close()
 
@@ -497,9 +500,6 @@ async def test_producer_connection_broke_with_send_batch(stream: str) -> None:
     async def on_connection_closed(disconnection_info: DisconnectionErrorInfo) -> None:
 
         nonlocal connection_broke
-        if connection_broke is True:
-            return None
-
         connection_broke = True
         nonlocal producer_broke
 
@@ -524,8 +524,15 @@ async def test_producer_connection_broke_with_send_batch(stream: str) -> None:
                 body="hello: {}".format(i),
             )
             batch.append(amqp_message)
-        await producer_broke.send_batch(stream, batch)  # type: ignore
-        batch.clear()
+        try:
+            if connection_broke is False:
+                await producer_broke.send_batch(stream, batch)  # type: ignore
+                batch.clear()
+            else:
+                break
+        # Connection closed
+        except:
+            break
 
     await producer_broke.close()
     assert connection_broke is True
@@ -569,11 +576,128 @@ async def test_super_stream_producer_connection_broke(super_stream: str) -> None
         )
         i = i + 1
         # send is asynchronous
-        await super_stream_producer_broke.send(message=amqp_message)
+        try:
+            if connection_broke is False:
+                await super_stream_producer_broke.send(message=amqp_message)
+            else:
+                break
+        # Connection closed
+        except:
+            break
 
     await super_stream_producer_broke.close()
 
     assert connection_broke is True
+    assert "test-super-stream-0" in streams_disconnected
+    assert "test-super-stream-1" in streams_disconnected
+    assert "test-super-stream-2" in streams_disconnected
+
+
+async def test_producer_connection_broke_with_reconnect(stream: str) -> None:
+
+    connection_broke = False
+    disconnected_once = False
+    stream_disconnected = None
+    producer_broke: Producer
+
+    async def on_connection_closed(disconnection_info: DisconnectionErrorInfo) -> None:
+        nonlocal connection_broke
+        connection_broke = True
+        nonlocal producer_broke
+
+        nonlocal stream_disconnected
+        # stream_disconnected = disconnection_info.streams.pop()
+
+        for stream in disconnection_info.streams:
+            stream_disconnected = stream
+            await producer_broke.reconnect_stream(stream)
+
+    producer_broke = Producer(
+        "localhost",
+        username="guest",
+        password="guest",
+        connection_closed_handler=on_connection_closed,
+        connection_name="test-connection",
+    )
+
+    await producer_broke.start()
+    asyncio.create_task(task_to_delete_connection("test-connection"))
+
+    while True:
+        try:
+            await producer_broke.send(stream, b"one")
+            if disconnected_once is True and connection_broke is True:
+                connection_broke = False
+                break
+        # Connection broke wait for reconnection
+        except:
+            disconnected_once = True
+            # wait for reconnection
+            await asyncio.sleep(2)
+            continue
+
+    await producer_broke.close()
+
+    assert disconnected_once is True
+    assert connection_broke is False
+    assert stream_disconnected == stream
+
+
+async def test_super_stream_producer_connection_broke_with_reconnect(super_stream: str) -> None:
+
+    connection_broke = False
+    disconnected_once = False
+    streams_disconnected: set[str] = set()
+    producer_broke: Producer
+
+    async def on_connection_closed(disconnection_info: DisconnectionErrorInfo) -> None:
+        nonlocal connection_broke
+        connection_broke = True
+        nonlocal producer_broke
+
+        nonlocal streams_disconnected
+        for stream in disconnection_info.streams:
+            streams_disconnected.add(stream)
+            await super_stream_producer_broke.reconnect_stream(stream)
+
+    super_stream_producer_broke = SuperStreamProducer(
+        "localhost",
+        username="guest",
+        password="guest",
+        routing_extractor=routing_extractor_generic,
+        routing=RouteType.Hash,
+        connection_closed_handler=on_connection_closed,
+        connection_name="test-connection",
+        super_stream=super_stream,
+    )
+
+    await super_stream_producer_broke.start()
+
+    asyncio.create_task(task_to_delete_connection("test-connection"))
+    i = 0
+    while True:
+        amqp_message = AMQPMessage(
+            body="hello: {}".format(i),
+            application_properties={"id": "{}".format(i)},
+        )
+        i = i + 1
+        # send is asynchronous
+        try:
+            await super_stream_producer_broke.send(message=amqp_message)
+            if disconnected_once is True and connection_broke is True:
+                connection_broke = False
+                break
+            # Connection broke wait for reconnection
+        except:
+            disconnected_once = True
+            # wait for reconnection
+            await asyncio.sleep(2)
+            continue
+
+    await super_stream_producer_broke.close()
+
+    assert disconnected_once is True
+    assert connection_broke is False
     assert "test-super-stream-0" in streams_disconnected
     assert "test-super-stream-1" in streams_disconnected
     assert "test-super-stream-2" in streams_disconnected


### PR DESCRIPTION
This closes https://github.com/qweeze/rstream/issues/135  
This closes https://github.com/qweeze/rstream/issues/141 
It should also complete the discussion we had in this issue: https://github.com/qweeze/rstream/issues/121

A new method reconnect_stream is implemented in order to reconnect to a stream in case of disconnection.

This is useful in case of super_stream in case we just loose connection to a partition and we may want simply to reconnect instead of closing the super_stream consumer/producer.

Also locator connections in super_stream are closed when not necessary anymore.

New examples and tests are provided.
