### PR TITLE
improving send_batch

### DIFF
--- a/docs/examples/basic_producers/README.md
+++ b/docs/examples/basic_producers/README.md
@@ -8,7 +8,8 @@ The library is using a dedicated background thread to send the messages to the R
 See producer_send.py
 * Using send_batch: Send batch is synchronous. You send a batch of messages and wait till they are sent to the server
 See producer_send_batch.py
-* Using send_wait: send_wait is synchronous and it will also wait until confirmation from the server have been received.
+* Using send_wait: send_wait is synchronous and it will block until confirmation from the server have been received.
+A timeout value can be specified (default 5s) in the method, after that an exception is raised.
 
 send and send_batch by default don't wait for confirmation. You can enable asynchronous confirmation through callbacks.
 You can find examples in producers_with_confirmations folder.

--- a/rstream/producer.py
+++ b/rstream/producer.py
@@ -276,6 +276,7 @@ class Producer:
         publisher_name: Optional[str] = None,
         callback: Optional[CB[ConfirmationStatus]] = None,
         sync: bool = True,
+        timeout: Optional[int] = None,
     ) -> list[int]:
 
         messages = []
@@ -318,7 +319,7 @@ class Producer:
         else:
             future: asyncio.Future[None] = asyncio.Future()
             self._waiting_for_confirm[publisher.reference][future] = publishing_ids.copy()
-            await future
+            await asyncio.wait_for(future, timeout)
 
         return list(publishing_ids)
 
@@ -415,6 +416,7 @@ class Producer:
         stream: str,
         message: MessageT,
         publisher_name: Optional[str] = None,
+        timeout: Optional[int] = 5,
     ) -> int:
 
         await self.check_connection()
@@ -424,6 +426,7 @@ class Producer:
             [message],
             publisher_name=publisher_name,
             sync=True,
+            timeout=timeout,
         )
         return publishing_ids[0]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,6 +90,15 @@ async def stream(client: Client):
 
 
 @pytest.fixture()
+async def stream2(client: Client):
+    await client.create_stream("test-stream-2")
+    try:
+        yield "test-stream-2"
+    finally:
+        await client.delete_stream("test-stream-2")
+
+
+@pytest.fixture()
 async def consumer(pytestconfig, ssl_context):
     consumer = Consumer(
         host=pytestconfig.getoption("rmq_host"),

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -77,6 +77,27 @@ async def test_publishing_several_messages(stream: str, producer: Producer, cons
     await wait_for(lambda: len(captured) == 100000)
 
 
+async def test_publishing_several_messages_different_streams(
+    stream: str, stream2: str, producer: Producer, consumer: Consumer
+) -> None:
+    captured_stream_1: list[bytes] = []
+    captured_stream_2: list[bytes] = []
+    await consumer.subscribe(
+        stream, callback=lambda message, message_context: captured_stream_1.append(bytes(message))
+    )
+    await consumer.subscribe(
+        stream2, callback=lambda message, message_context: captured_stream_2.append(bytes(message))
+    )
+
+    for i in range(0, 100000):
+        await producer.send(stream, b"one")
+    for i in range(0, 100000):
+        await producer.send(stream2, b"one")
+
+    await wait_for(lambda: len(captured_stream_1) == 100000)
+    await wait_for(lambda: len(captured_stream_2) == 100000)
+
+
 async def test_publishing_sequence_subbatching_nocompression(
     stream: str, producer: Producer, consumer: Consumer
 ) -> None:


### PR DESCRIPTION
This PR improves send_batch performance.

It decouples send_batch from send/send_sub_batch.

In this way we don't need the wrapper list of messages anymore for this case and we safe a loop.

We gain about 15% of performance.

This also reviewed send_wait
This also closes #82 