### PR TITLE
use send_publish_frame in send_batch too

### DIFF
--- a/rstream/producer.py
+++ b/rstream/producer.py
@@ -300,7 +300,7 @@ class Producer:
             )
 
         if len(messages) > 0:
-            await publisher.client.send_frame(
+            await publisher.client.send_publish_frame(
                 schema.Publish(
                     publisher_id=publisher.id,
                     messages=messages,


### PR DESCRIPTION
It seems like there was an issue when merging #149 

It seems like the frame optimization implemented wasn't ported for _send_batch but just for send.

This should improve performance of another 10/15% for send_batch.

