### PR TITLE
adding support for CREATE/DELETE supersteams

### DIFF
--- a/docs/examples/reliable_client/BestPracticesClient.py
+++ b/docs/examples/reliable_client/BestPracticesClient.py
@@ -19,6 +19,7 @@ from rstream import (
     SuperStreamConsumer,
     SuperStreamProducer,
     amqp_decoder,
+    SuperStreamCreationOption,
 )
 
 # global variables needed by the test
@@ -71,6 +72,7 @@ async def make_producer(rabbitmq_data: dict) -> Producer | SuperStreamProducer:
         )
 
     else:
+        super_stream_creation_opt = SuperStreamCreationOption(n_partitions=rabbitmq_data["Producers"])
         producer = SuperStreamProducer(  # type: ignore
             host=host,
             username=username,
@@ -79,6 +81,7 @@ async def make_producer(rabbitmq_data: dict) -> Producer | SuperStreamProducer:
             vhost=vhost,
             load_balancer_mode=load_balancer,
             super_stream=stream_name,
+            super_stream_creation_option=super_stream_creation_opt,
             routing=RouteType.Hash,
             routing_extractor=routing_extractor,
         )
@@ -319,5 +322,4 @@ async def main():
         await consumer_task
 
 
-asyncio.run(main())
 asyncio.run(main())

--- a/docs/examples/reliable_client/BestPracticesClient.py
+++ b/docs/examples/reliable_client/BestPracticesClient.py
@@ -17,9 +17,9 @@ from rstream import (
     Producer,
     RouteType,
     SuperStreamConsumer,
+    SuperStreamCreationOption,
     SuperStreamProducer,
     amqp_decoder,
-    SuperStreamCreationOption,
 )
 
 # global variables needed by the test

--- a/docs/examples/reliable_client/BestPracticesClient.py
+++ b/docs/examples/reliable_client/BestPracticesClient.py
@@ -72,7 +72,7 @@ async def make_producer(rabbitmq_data: dict) -> Producer | SuperStreamProducer:
         )
 
     else:
-        super_stream_creation_opt = SuperStreamCreationOption(n_partitions=rabbitmq_data["Producers"])
+        super_stream_creation_opt = SuperStreamCreationOption(n_partitions=3)
         producer = SuperStreamProducer(  # type: ignore
             host=host,
             username=username,
@@ -141,6 +141,7 @@ async def make_consumer(rabbitmq_data: dict) -> Consumer | SuperStreamConsumer:
         )
 
     else:
+        super_stream_creation_opt = SuperStreamCreationOption(n_partitions=3)
         consumer = SuperStreamConsumer(  # type: ignore
             host=host,
             username=username,
@@ -149,6 +150,7 @@ async def make_consumer(rabbitmq_data: dict) -> Consumer | SuperStreamConsumer:
             vhost=vhost,
             load_balancer_mode=load_balancer,
             super_stream=stream_name,
+            super_stream_creation_option=super_stream_creation_opt,
             on_close_handler=on_close_connection,
         )
 

--- a/docs/examples/reliable_client/README.md
+++ b/docs/examples/reliable_client/README.md
@@ -28,3 +28,18 @@ After this the client can try to reconnect.
 
 As you can see in the example the Consumer and Superstream consumers take a on_close_handler callback which inside it is
 checking the stream which has been disconnected and then using the reconnect_stream in order to
+
+### Creation of super-stream
+The SuperStreamProducer class takes in input a field: super_stream_creation_option of type
+
+```
+class SuperStreamCreationOption:
+    n_partitions: int
+    binding_keys: Optional[list[str]] = None
+    arguments: Optional[dict[str, Any]] = None
+```
+
+If you want to create simple partitions you can specify the n_partitions field and leave to None the binding_keys field.
+Otherwise if you want to create the partitions based on the binding_keys you can specify this field and leave to 0 the n_partitions field
+If the super_stream specified in the super_stream field doesn't exist and super_stream_creation_option is set then it will create the super stream.
+See: https://github.com/qweeze/rstream/issues/156 for more info

--- a/docs/examples/super_stream/README.md
+++ b/docs/examples/super_stream/README.md
@@ -7,13 +7,15 @@ Super stream example
 
 Step 1: Create the super stream (routing keys are necessary for binding keys resolution strategy):
 
-The stream is automatically created by the SuperStreamProducer constructor if it doesn't exist
+The stream is automatically created by the SuperStreamProducer/SuperStreamConsumer constructor if it doesn't exist
 
 You can specify the numer of the partitions using this struct (in line 23 of super_stream_producer.py):
 
 super_stream_creation_opt = SuperStreamCreationOption(n_partitions=3)
 
 and passing this struct to the SuperStreamProducer constructor (line 31)
+
+Same for SuperStreamConsumer
 
 Step 2: Run the Super stream producer (with hash strategy):
 

--- a/docs/examples/super_stream/README.md
+++ b/docs/examples/super_stream/README.md
@@ -7,8 +7,13 @@ Super stream example
 
 Step 1: Create the super stream (routing keys are necessary for binding keys resolution strategy):
 
-    $ rabbitmq-streams add_super_stream invoices --routing-keys=key1,key2,key3
+The stream is automatically created by the SuperStreamProducer constructor if it doesn't exist
 
+You can specify the numer of the partitions using this struct (in line 23 of super_stream_producer.py):
+
+super_stream_creation_opt = SuperStreamCreationOption(n_partitions=3)
+
+and passing this struct to the SuperStreamProducer constructor (line 31)
 
 Step 2: Run the Super stream producer (with hash strategy):
 

--- a/docs/examples/super_stream/super_stream_consumer.py
+++ b/docs/examples/super_stream/super_stream_consumer.py
@@ -1,6 +1,5 @@
 import asyncio
 import signal
-from typing import Optional
 
 from rstream import (
     AMQPMessage,
@@ -8,6 +7,7 @@ from rstream import (
     MessageContext,
     OffsetType,
     SuperStreamConsumer,
+    SuperStreamCreationOption,
     amqp_decoder,
 )
 
@@ -21,8 +21,15 @@ async def on_message(msg: AMQPMessage, message_context: MessageContext):
 
 
 async def consume():
+    super_stream_creation_opt = SuperStreamCreationOption(n_partitions=3)
     consumer = SuperStreamConsumer(
-        host="localhost", port=5552, vhost="/", username="guest", password="guest", super_stream="invoices"
+        host="localhost",
+        port=5552,
+        vhost="/",
+        username="guest",
+        password="guest",
+        super_stream="invoices",
+        super_stream_creation_option=super_stream_creation_opt,
     )
 
     loop = asyncio.get_event_loop()

--- a/docs/examples/super_stream/super_stream_producer.py
+++ b/docs/examples/super_stream/super_stream_producer.py
@@ -4,10 +4,11 @@ import time
 from rstream import (
     AMQPMessage,
     RouteType,
+    SuperStreamCreationOption,
     SuperStreamProducer,
 )
 
-SUPER_STREAM = "invoices"
+SUPER_STREAM = "invoices3"
 MESSAGES = 1000000
 
 
@@ -17,14 +18,18 @@ async def routing_extractor(message: AMQPMessage) -> str:
 
 
 async def publish():
+    # Struct used to pass information to the SuperStreamProducer
+    # in order to create a superstream
+    super_stream_creation_opt = SuperStreamCreationOption(n_partitions=3)
     # SuperStreamProducer wraps a Producer
     async with SuperStreamProducer(
-        "localhost",
+        host="localhost",
         username="guest",
         password="guest",
         routing_extractor=routing_extractor,
-        routing=RouteType.Hash,
         super_stream=SUPER_STREAM,
+        super_stream_creation_option=super_stream_creation_opt,
+        routing=RouteType.Hash,
     ) as super_stream_producer:
         # Sending a million messages
 

--- a/docs/examples/super_stream/super_stream_producer_key.py
+++ b/docs/examples/super_stream/super_stream_producer_key.py
@@ -18,6 +18,12 @@ async def routing_extractor(message: AMQPMessage) -> str:
 
 async def publish():
     # SuperStreamProducer wraps a Producer
+    # Struct used to pass information to the SuperStreamProducer
+    # in order to create a superstream
+    super_stream_creation_opt = SuperStreamCreationOption(
+        n_partitions=0, binding_keys=["key1", "key2", "key3"]
+    )
+
     async with SuperStreamProducer(
         "localhost",
         username="guest",

--- a/rstream/__init__.py
+++ b/rstream/__init__.py
@@ -44,8 +44,9 @@ from .superstream_consumer import (  # noqa: E402
 from .superstream_producer import (  # noqa: E402
     RouteType,
     SuperStreamProducer,
-    SuperStreamCreationOption,
 )
+
+from .superstream import SuperStreamCreationOption  # noqa: E402; noqa: E402
 
 from .constants import OffsetType  # noqa: E402; noqa: E402
 

--- a/rstream/__init__.py
+++ b/rstream/__init__.py
@@ -44,6 +44,7 @@ from .superstream_consumer import (  # noqa: E402
 from .superstream_producer import (  # noqa: E402
     RouteType,
     SuperStreamProducer,
+    SuperStreamCreationOption,
 )
 
 from .constants import OffsetType  # noqa: E402; noqa: E402
@@ -70,4 +71,5 @@ __all__ = [
     "OnClosedErrorInfo",
     "SlasMechanism",
     "FilterConfiguration",
+    "SuperStreamCreationOption",
 ]

--- a/rstream/client.py
+++ b/rstream/client.py
@@ -187,7 +187,7 @@ class BaseClient:
         except socket.error:
             self._is_not_closed = False
             if self._connection_closed_handler is not None:
-                logger.debug("TCP connection closed")
+                logger.warning("TCP connection closed")
             else:
                 logger.exception("TCP connection closed")
 
@@ -200,7 +200,7 @@ class BaseClient:
         except socket.error:
             self._is_not_closed = False
             if self._connection_closed_handler is not None:
-                logger.debug("TCP connection closed")
+                logger.warning("TCP connection closed")
             else:
                 logger.exception("TCP connection closed")
 
@@ -284,7 +284,7 @@ class BaseClient:
                                 await maybe_coro
 
                     except BaseException:
-                        logger.error("Error while running handler %s of frame %s", handler, frame)
+                        logger.exception("Error while running handler %s of frame %s", handler, frame)
         except (ConnectionClosed, socket.error):
             self._is_not_closed = False
             if self._connection_closed_handler is not None:

--- a/rstream/client.py
+++ b/rstream/client.py
@@ -452,6 +452,27 @@ class Client(BaseClient):
             resp_schema=schema.CreateResponse,
         )
 
+    async def create_super_stream(
+        self,
+        super_stream: str,
+        partitions: list[str],
+        binding_keys: list[str],
+        arguments: Optional[dict[str, Any]] = None,
+    ) -> None:
+        if arguments is None:
+            arguments = {}
+
+        await self.sync_request(
+            schema.CreateSuperStream(
+                self._corr_id_seq.next(),
+                super_stream=super_stream,
+                partitions=partitions,
+                binding_keys=binding_keys,
+                arguments=[schema.Property(key, str(val)) for key, val in arguments.items()],
+            ),
+            resp_schema=schema.CreateSuperStreamResponse,
+        )
+
     async def delete_stream(self, stream: str) -> None:
         await self.sync_request(
             schema.Delete(
@@ -459,6 +480,15 @@ class Client(BaseClient):
                 stream=stream,
             ),
             resp_schema=schema.DeleteResponse,
+        )
+
+    async def delete_super_stream(self, super_stream: str) -> None:
+        await self.sync_request(
+            schema.DeleteSuperStream(
+                self._corr_id_seq.next(),
+                super_stream=super_stream,
+            ),
+            resp_schema=schema.DeleteSuperStreamResponse,
         )
 
     async def stream_exists(self, stream: str) -> bool:

--- a/rstream/client.py
+++ b/rstream/client.py
@@ -349,7 +349,7 @@ class BaseClient:
                     )
 
                 except asyncio.TimeoutError:
-                    logger.error("timeout in client close() sync_request:")
+                    logger.warning("timeout in client close() sync_request:")
                 except BaseException as exc:
                     logger.exception("exception in client close() sync_request", exc)
 

--- a/rstream/constants.py
+++ b/rstream/constants.py
@@ -45,6 +45,8 @@ class Key(enum.Enum):
     Partitions = 25
     ConsumerUpdate = 26
     CommandExchangeCommandVersion = 27
+    CommandCreateSuperStream = 29
+    CommandDeleteSuperStream = 30
     ConsumerUpdateRequest = 32794
 
 

--- a/rstream/consumer.py
+++ b/rstream/consumer.py
@@ -425,10 +425,13 @@ class Consumer:
             finally:
                 await self._close_locator_connection()
 
-    async def delete_stream(self, stream: str, missing_ok: bool = False) -> None:
+    async def clean_up_subscribers(self, stream: str):
         for subscriber in list(self._subscribers.values()):
             if subscriber.stream == stream:
                 del self._subscribers[subscriber.reference]
+
+    async def delete_stream(self, stream: str, missing_ok: bool = False) -> None:
+        await self.clean_up_subscribers(stream)
 
         async with self._lock:
             try:

--- a/rstream/consumer.py
+++ b/rstream/consumer.py
@@ -310,9 +310,9 @@ class Consumer:
         try:
             await asyncio.wait_for(subscriber.client.unsubscribe(subscriber.subscription_id), 5)
         except asyncio.TimeoutError:
-            logger.error("timeout when closing consumer and deleting publisher")
+            logger.warning("timeout when closing consumer and deleting publisher")
         except BaseException as exc:
-            logger.error("exception in delete_publisher in Producer.close:", exc)
+            logger.error("exception in unsubscribe of Consumer:" + str(exc))
 
         del self._subscribers[subscriber_name]
 

--- a/rstream/consumer.py
+++ b/rstream/consumer.py
@@ -312,7 +312,7 @@ class Consumer:
         except asyncio.TimeoutError:
             logger.warning("timeout when closing consumer and deleting publisher")
         except BaseException as exc:
-            logger.error("exception in unsubscribe of Consumer:" + str(exc))
+            logger.warning("exception in unsubscribe of Consumer:" + str(exc))
 
         del self._subscribers[subscriber_name]
 

--- a/rstream/producer.py
+++ b/rstream/producer.py
@@ -178,7 +178,7 @@ class Producer:
                 try:
                     await asyncio.wait_for(publisher.client.delete_publisher(publisher.id), 5)
                 except asyncio.TimeoutError:
-                    logger.error("timeout when closing producer and deleting publisher")
+                    logger.warning("timeout when closing producer and deleting publisher")
                 except BaseException as exc:
                     logger.error("exception in delete_publisher in Producer.close:", exc)
             publisher.client.remove_handler(schema.PublishConfirm, publisher.reference)
@@ -760,7 +760,7 @@ class Producer:
                     self._publishers[stream].client.delete_publisher(self._publishers[stream].id), 3
                 )
             except asyncio.TimeoutError:
-                logger.error("Timeout deleting publisher in maybe_clean_up_during_lost_connection")
+                logger.warning("Timeout deleting publisher in maybe_clean_up_during_lost_connection")
             if self._publishers[stream].client.is_connection_alive():
                 await self._publishers[stream].client.remove_stream(stream)
                 await self._publishers[stream].client.free_available_id(self._publishers[stream].id)

--- a/rstream/schema.py
+++ b/rstream/schema.py
@@ -172,6 +172,20 @@ class DeleteResponse(Frame, is_response=True):
 
 
 @dataclass
+class DeleteSuperStream(Frame):
+    key = Key.CommandDeleteSuperStream
+    correlation_id: int = field(metadata={"type": T.uint32})
+    super_stream: str = field(metadata={"type": T.string})
+
+
+@dataclass
+class DeleteSuperStreamResponse(Frame, is_response=True):
+    key = Key.CommandDeleteSuperStream
+    correlation_id: int = field(metadata={"type": T.uint32})
+    response_code: int = field(metadata={"type": T.uint16})
+
+
+@dataclass
 class DeclarePublisher(Frame):
     key = Key.DeclarePublisher
     correlation_id: int = field(metadata={"type": T.uint32})
@@ -581,6 +595,23 @@ class ConsumerUpdateServerResponse(Frame, is_response=True):
     correlation_id: int = field(metadata={"type": T.uint32})
     response_code: int = field(metadata={"type": T.uint16})
     offset_specification: OffsetSpecification
+
+
+@dataclass
+class CreateSuperStream(Frame):
+    key = Key.CommandCreateSuperStream
+    correlation_id: int = field(metadata={"type": T.uint32})
+    super_stream: str = field(metadata={"type": T.string})
+    partitions: list[str] = field(metadata={"type": [T.string]})
+    binding_keys: list[str] = field(metadata={"type": [T.string]})
+    arguments: list[Property]
+
+
+@dataclass
+class CreateSuperStreamResponse(Frame, is_response=True):
+    key = Key.CommandCreateSuperStream
+    correlation_id: int = field(metadata={"type": T.uint32})
+    response_code: int = field(metadata={"type": T.uint16})
 
 
 def is_struct(obj: Any) -> bool:

--- a/rstream/superstream.py
+++ b/rstream/superstream.py
@@ -3,11 +3,13 @@
 
 import abc
 import logging
+from dataclasses import dataclass
 from typing import (
     Annotated,
     Any,
     Awaitable,
     Callable,
+    Optional,
     TypeVar,
 )
 
@@ -91,3 +93,10 @@ class HashRoutingMurmurStrategy(RoutingStrategy):
         streams.append(stream)
 
         return streams
+
+
+@dataclass
+class SuperStreamCreationOption:
+    n_partitions: int
+    binding_keys: Optional[list[str]] = None
+    arguments: Optional[dict[str, Any]] = None

--- a/rstream/superstream_producer.py
+++ b/rstream/superstream_producer.py
@@ -154,13 +154,6 @@ class SuperStreamProducer:
         await self.close()
 
     async def start(self) -> None:
-        self._default_client = await self._pool.get(connection_name="rstream-locator")
-        self.super_stream_metadata = DefaultSuperstreamMetadata(self.super_stream, self._default_client)
-        if self.routing == RouteType.Hash:
-            self._routing_strategy = HashRoutingMurmurStrategy(self.routing_extractor)
-        else:
-            self._routing_strategy = RoutingKeyRoutingStrategy(self.routing_extractor)
-
         if self.super_stream_creation_option is not None:
             await self.create_super_stream(
                 self.super_stream,
@@ -169,6 +162,12 @@ class SuperStreamProducer:
                 self.super_stream_creation_option.arguments,
                 True,
             )
+        self._default_client = await self._pool.get(connection_name="rstream-locator")
+        self.super_stream_metadata = DefaultSuperstreamMetadata(self.super_stream, self._default_client)
+        if self.routing == RouteType.Hash:
+            self._routing_strategy = HashRoutingMurmurStrategy(self.routing_extractor)
+        else:
+            self._routing_strategy = RoutingKeyRoutingStrategy(self.routing_extractor)
 
     async def close(self) -> None:
         if self._default_client is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,11 +13,6 @@ from rstream import (
 )
 from rstream.client import Client
 
-from .http_requests import (
-    create_binding,
-    create_exchange,
-    delete_exchange,
-)
 from .util import (
     filter_value_extractor,
     routing_extractor,
@@ -156,39 +151,15 @@ async def producer_with_filtering(pytestconfig, ssl_context):
 
 @pytest.fixture()
 async def super_stream(client: Client):
-    # create an exchange to connect the 3 supersteams
-    super_stream = "test-super-stream"
-    status_code = create_exchange(exchange_name=super_stream)
-    assert status_code == 201 or status_code == 204
-
-    await client.create_stream(super_stream + "-0")
-    await client.create_stream(super_stream + "-1")
-    await client.create_stream(super_stream + "-2")
-
-    # create binding with exchange
-    status_code = create_binding(
-        exchange_name=super_stream, routing_key="key1", stream_name=super_stream + "-0"
+    await client.create_super_stream(
+        "test-super-stream",
+        ["test-super-stream-0", "test-super-stream-1", "test-super-stream-2"],
+        ["key1", "key2", "key3"],
     )
-    assert status_code == 201 or status_code == 204
-    status_code = create_binding(
-        exchange_name=super_stream, routing_key="key2", stream_name=super_stream + "-1"
-    )
-    assert status_code == 201 or status_code == 204
-    status_code = create_binding(
-        exchange_name=super_stream, routing_key="key3", stream_name=super_stream + "-2"
-    )
-    assert status_code == 201 or status_code == 204
-
     try:
         yield "test-super-stream"
-    #
     finally:
-        await client.delete_stream(super_stream + "-0")
-        await client.delete_stream(super_stream + "-1")
-        await client.delete_stream(super_stream + "-2")
-
-        status_code = delete_exchange(exchange_name=super_stream)
-        assert status_code == 201 or status_code == 204
+        await client.delete_super_stream("test-super-stream")
 
 
 @pytest.fixture()

--- a/tests/http_requests.py
+++ b/tests/http_requests.py
@@ -4,28 +4,6 @@ import requests
 from requests.auth import HTTPBasicAuth
 
 
-def create_exchange(exchange_name: str) -> int:
-    request = "http://guest:guest@localhost:15672/api/exchanges/%2f" + "/" + exchange_name
-    response = requests.put(request)
-    return response.status_code
-
-
-def delete_exchange(exchange_name: str) -> int:
-    request = "http://guest:guest@localhost:15672/api/exchanges/%2f" + "/" + exchange_name
-    response = requests.delete(request)
-    return response.status_code
-
-
-def create_binding(exchange_name: str, routing_key: str, stream_name: str):
-    data = {
-        "routing_key": routing_key,
-    }
-    request = "http://guest:guest@localhost:15672/api/bindings/%2f/e/" + exchange_name + "/q/" + stream_name
-
-    response = requests.post(request, json=data)
-    return response.status_code
-
-
 def get_connections() -> list:
     request = "http://localhost:15672/api/connections"
     response = requests.get(request, auth=HTTPBasicAuth("guest", "guest"))

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -51,6 +51,33 @@ async def test_create_stream_already_exists(stream: str, consumer: Consumer) -> 
         pytest.fail("Unexpected error")
 
 
+async def test_create_super_stream_already_exists(
+    super_stream: str, super_stream_consumer: SuperStreamConsumer
+) -> None:
+    with pytest.raises(exceptions.StreamAlreadyExists):
+        await super_stream_consumer.create_super_stream(super_stream, n_partitions=3)
+
+    try:
+        await super_stream_consumer.create_super_stream(super_stream, n_partitions=3, exists_ok=True)
+    except Exception:
+        pytest.fail("Unexpected error")
+
+
+async def test_create_and_delete_severalsuper_stream(
+    super_stream: str, super_stream_consumer: SuperStreamConsumer
+) -> None:
+    await super_stream_consumer.create_super_stream("test-super-stream1", n_partitions=3)
+    await super_stream_consumer.create_super_stream(
+        "test-super-stream2", n_partitions=0, binding_keys=["0", "1", "2"]
+    )
+    await super_stream_consumer.delete_super_stream("test-super-stream1")
+    await super_stream_consumer.create_super_stream("test-super-stream1", n_partitions=3, exists_ok=True)
+
+    await super_stream_consumer.create_super_stream("test-super-stream2", n_partitions=3, exists_ok=True)
+    await super_stream_consumer.delete_super_stream("test-super-stream2")
+    await super_stream_consumer.delete_super_stream("test-super-stream1")
+
+
 async def test_delete_stream_doesnt_exist(consumer: Consumer) -> None:
     with pytest.raises(exceptions.StreamDoesNotExist):
         await consumer.delete_stream("not-existing-stream")

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -42,12 +42,34 @@ async def test_create_stream_already_exists(stream: str, producer: Producer) -> 
         pytest.fail("Unexpected error")
 
 
+async def test_create_super_stream_already_exists(
+    super_stream: str, super_stream_producer: SuperStreamProducer
+) -> None:
+    with pytest.raises(exceptions.StreamAlreadyExists):
+        await super_stream_producer.create_super_stream(super_stream, n_partitions=3)
+
+    try:
+        await super_stream_producer.create_super_stream(super_stream, n_partitions=3, exists_ok=True)
+    except Exception:
+        pytest.fail("Unexpected error")
+
+
 async def test_delete_stream_doesnt_exist(producer: Producer) -> None:
     with pytest.raises(exceptions.StreamDoesNotExist):
         await producer.delete_stream("not-existing-stream")
 
     try:
         await producer.delete_stream("not-existing-stream", missing_ok=True)
+    except Exception:
+        pytest.fail("Unexpected error")
+
+
+async def test_delete_super_stream_doesnt_exist(super_stream_producer: SuperStreamProducer) -> None:
+    with pytest.raises(exceptions.StreamDoesNotExist):
+        await super_stream_producer.delete_super_stream("not-existing-stream")
+
+    try:
+        await super_stream_producer.delete_super_stream("not-existing-stream", missing_ok=True)
     except Exception:
         pytest.fail("Unexpected error")
 

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -54,6 +54,21 @@ async def test_create_super_stream_already_exists(
         pytest.fail("Unexpected error")
 
 
+async def test_create_and_delete_severalsuper_stream(
+    super_stream: str, super_stream_producer: SuperStreamProducer
+) -> None:
+    await super_stream_producer.create_super_stream("test-super-stream1", n_partitions=3)
+    await super_stream_producer.create_super_stream(
+        "test-super-stream2", n_partitions=0, binding_keys=["0", "1", "2"]
+    )
+    await super_stream_producer.delete_super_stream("test-super-stream1")
+    await super_stream_producer.create_super_stream("test-super-stream1", n_partitions=3, exists_ok=True)
+
+    await super_stream_producer.create_super_stream("test-super-stream2", n_partitions=3, exists_ok=True)
+    await super_stream_producer.delete_super_stream("test-super-stream2")
+    await super_stream_producer.delete_super_stream("test-super-stream1")
+
+
 async def test_delete_stream_doesnt_exist(producer: Producer) -> None:
     with pytest.raises(exceptions.StreamDoesNotExist):
         await producer.delete_stream("not-existing-stream")


### PR DESCRIPTION
This closes #156 

The SuperstreamProducer is now taking in input a new field: super_stream_creation_option of type

```
class SuperStreamCreationOption:
    n_partitions: int
    binding_keys: Optional[list[str]] = None
    arguments: Optional[dict[str, Any]] = None
```

If the super_stream specified in the super_stream field doesn't exist and super_stream_creation_option is set then it will create the super stream.

Also create_super_stream and delete_super_stream have been implemented in the SuperstreamProducer class