### PR TITLE
implementing maxProducersByConnection and maxConsumerByConnection

### DIFF
--- a/docs/examples/reliable_client/BestPracticesClient.py
+++ b/docs/examples/reliable_client/BestPracticesClient.py
@@ -60,6 +60,8 @@ async def make_producer(rabbitmq_data: dict) -> Producer | SuperStreamProducer:
     vhost = rabbitmq_data["Virtualhost"]
     load_balancer = bool(rabbitmq_data["LoadBalancer"])
     stream_name = rabbitmq_data["StreamName"]
+    max_publishers_by_connection = rabbitmq_data["MaxPublishersByConnection"]
+    producers = rabbitmq_data["Producers"]
 
     if bool(rabbitmq_data["SuperStream"]) is False:
         producer = Producer(
@@ -69,16 +71,18 @@ async def make_producer(rabbitmq_data: dict) -> Producer | SuperStreamProducer:
             port=port,
             vhost=vhost,
             load_balancer_mode=load_balancer,
+            max_publishers_by_connection=max_publishers_by_connection,
         )
 
     else:
-        super_stream_creation_opt = SuperStreamCreationOption(n_partitions=3)
+        super_stream_creation_opt = SuperStreamCreationOption(n_partitions=int(producers))
         producer = SuperStreamProducer(  # type: ignore
             host=host,
             username=username,
             password=password,
             port=port,
             vhost=vhost,
+            max_publishers_by_connection=max_publishers_by_connection,
             load_balancer_mode=load_balancer,
             super_stream=stream_name,
             super_stream_creation_option=super_stream_creation_opt,
@@ -128,6 +132,8 @@ async def make_consumer(rabbitmq_data: dict) -> Consumer | SuperStreamConsumer:
     vhost = rabbitmq_data["Virtualhost"]
     load_balancer = bool(rabbitmq_data["LoadBalancer"])
     stream_name = rabbitmq_data["StreamName"]
+    n_producers = rabbitmq_data["Producers"]
+    max_subscribers_by_connection = rabbitmq_data["MaxSubscribersByConnection"]
 
     if bool(rabbitmq_data["SuperStream"]) is False:
         consumer = Consumer(
@@ -138,10 +144,11 @@ async def make_consumer(rabbitmq_data: dict) -> Consumer | SuperStreamConsumer:
             vhost=vhost,
             load_balancer_mode=load_balancer,
             on_close_handler=on_close_connection,
+            max_subscribers_by_connection=max_subscribers_by_connection,
         )
 
     else:
-        super_stream_creation_opt = SuperStreamCreationOption(n_partitions=3)
+        super_stream_creation_opt = SuperStreamCreationOption(n_partitions=int(n_producers))
         consumer = SuperStreamConsumer(  # type: ignore
             host=host,
             username=username,
@@ -152,6 +159,7 @@ async def make_consumer(rabbitmq_data: dict) -> Consumer | SuperStreamConsumer:
             super_stream=stream_name,
             super_stream_creation_option=super_stream_creation_opt,
             on_close_handler=on_close_connection,
+            max_subscribers_by_connection=max_subscribers_by_connection,
         )
 
     return consumer

--- a/docs/examples/reliable_client/appsettings.json
+++ b/docs/examples/reliable_client/appsettings.json
@@ -1,17 +1,19 @@
 {
   "RabbitMQ": {
-    "Host": "localhost",
-    "Username": "guest",
-    "Password": "guest",
+    "Host": "34.147.210.193",
+    "Username": "default_user_4RVgi_YtwKGw7xlGPIi",
+    "Password": "3urSCJfSnaZal6d_VsCSJRrUwar_iTOA",
     "Port": 5552,
     "Virtualhost": "/",
     "LoadBalancer": true,
-    "SuperStream": false,
+    "SuperStream": true,
+    "MaxPublishersByConnection": 256,
+    "MaxSubscribersByConnection": 256,
     "Producers": 3,
     "Consumers": 3,
     "DelayDuringSendMs":0,
-    "MessagesToSend": 100000,
-    "StreamName": "PythonClientTest",
+    "MessagesToSend": 10000000,
+    "StreamName": "invoices",
     "Logging": ""
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rstream"
-version = "0.18.0"
+version = "0.19.0"
 description = "A python client for RabbitMQ Streams"
 authors = ["George Fortunatov <qweeeze@gmail.com>", "Daniele Palaia <dpalaia@vmware.com>"]
 readme = "README.md"

--- a/rstream/client.py
+++ b/rstream/client.py
@@ -164,19 +164,12 @@ class BaseClient:
             self._streams.remove(stream)
 
     async def get_available_id(self) -> int:
-        if self._current_id < self._max_clients_by_connections:
-            publishing_subscribing_id = self._current_id
-            self._available_client_ids[publishing_subscribing_id] = False
-            self._current_id = self._current_id + 1
-            return publishing_subscribing_id
-        else:
-            self._current_id = 0
-            for publishing_subscribing_id in range(self._current_id, self._max_clients_by_connections):
-                if self._available_client_ids[publishing_subscribing_id] is True:
-                    self._available_client_ids[publishing_subscribing_id] = False
-                    self._current_id = publishing_subscribing_id
-                    return publishing_subscribing_id
-            return self._current_id
+        for publishing_subscribing_id in range(0, self._max_clients_by_connections):
+            if self._available_client_ids[publishing_subscribing_id] is True:
+                self._available_client_ids[publishing_subscribing_id] = False
+                self._current_id = publishing_subscribing_id
+                return publishing_subscribing_id
+        return self._current_id
 
     async def get_count_available_ids(self):
         count = 0

--- a/rstream/client.py
+++ b/rstream/client.py
@@ -69,6 +69,7 @@ class BaseClient:
         frame_max: int,
         heartbeat: int,
         connection_name: Optional[str] = "",
+        max_clients_by_connections=256,
         connection_closed_handler: Optional[CB[OnClosedErrorInfo]] = None,
         sasl_configuration_mechanism: SlasMechanism = SlasMechanism.MechanismPlain,
     ):
@@ -103,9 +104,11 @@ class BaseClient:
 
         self._frames: dict[str, asyncio.Queue] = defaultdict(asyncio.Queue)
         self._is_not_closed: bool = True
+        self._max_clients_by_connections = max_clients_by_connections
 
         self._streams: list[str] = []
-        self._available_ids: list[bool] = [True for i in range(257)]
+        # used to assing publish_ids and subscribe_ids
+        self._available_client_ids: list[bool] = [True for i in range(max_clients_by_connections + 1)]
         self._current_id = 1
 
     def start_task(self, name: str, coro: Awaitable[None]) -> None:
@@ -161,22 +164,29 @@ class BaseClient:
             self._streams.remove(stream)
 
     async def get_available_id(self) -> int:
-        if self._current_id <= 256:
-            publishing_id = self._current_id
-            self._available_ids[publishing_id] = False
+        if self._current_id <= self._max_clients_by_connections:
+            publishing_subscribing_id = self._current_id
+            self._available_client_ids[publishing_subscribing_id] = False
             self._current_id = self._current_id + 1
-            return publishing_id
+            return publishing_subscribing_id
         else:
             self._current_id = 1
-            for publishing_id in range(self._current_id, 257):
-                if self._available_ids[publishing_id] is True:
-                    self._available_ids[publishing_id] = False
-                    self._current_id = publishing_id
-                    return publishing_id
+            for publishing_subscribing_id in range(self._current_id, self._max_clients_by_connections):
+                if self._available_client_ids[publishing_subscribing_id] is True:
+                    self._available_client_ids[publishing_subscribing_id] = False
+                    self._current_id = publishing_subscribing_id
+                    return publishing_subscribing_id
             return self._current_id
 
-    async def free_available_id(self, publishing_id):
-        self._available_ids[publishing_id] = True
+    async def get_count_available_ids(self):
+        count = 0
+        for slot in self._available_client_ids:
+            if slot is True:
+                count = count + 1
+        return count
+
+    async def free_available_id(self, publishing_subscribing_id):
+        self._available_client_ids[publishing_subscribing_id] = True
 
     async def send_publish_frame(self, frame: schema.Publish, version: int = 1) -> None:
         logger.debug("Sending frame: %s", frame)
@@ -712,7 +722,7 @@ class ClientPool:
 
         self._frame_max = frame_max
         self._heartbeat = heartbeat
-        self._clients: dict[Addr, Client] = {}
+        self._clients: dict[Addr, list[Client]] = defaultdict(list)
 
     async def get(
         self,
@@ -721,6 +731,7 @@ class ClientPool:
         connection_closed_handler: Optional[CB[OnClosedErrorInfo]] = None,
         stream: Optional[str] = None,
         sasl_configuration_mechanism: SlasMechanism = SlasMechanism.MechanismPlain,
+        max_clients_by_connections: int = 256,
     ) -> Client:
         """Get a client according to `addr` parameter
 
@@ -732,26 +743,40 @@ class ClientPool:
         """
         desired_addr = addr or self.addr
 
-        if desired_addr not in self._clients or self._clients[desired_addr].is_connection_alive() is False:
-            if addr and self.load_balancer_mode:
-                self._clients[desired_addr] = await self._resolve_broker(
+        # check if at least one client of desired_addr is connected
+        if desired_addr in self._clients:
+            for client in self._clients[desired_addr]:
+                if client.is_connection_alive() is True and await client.get_count_available_ids() > 1:
+                    if stream is not None:
+                        client.add_stream(stream)
+                    return client
+
+        if addr and self.load_balancer_mode:
+            self._clients[desired_addr].append(
+                await self._resolve_broker(
                     addr=desired_addr,
                     connection_closed_handler=connection_closed_handler,
                     connection_name=connection_name,
                     sasl_configuration_mechanism=sasl_configuration_mechanism,
+                    max_clients_by_connections=max_clients_by_connections,
                 )
-            else:
-                self._clients[desired_addr] = await self.new(
+            )
+        else:
+            self._clients[desired_addr].append(
+                await self.new(
                     addr=desired_addr,
                     connection_closed_handler=connection_closed_handler,
                     connection_name=connection_name,
                     sasl_configuration_mechanism=sasl_configuration_mechanism,
+                    max_clients_by_connections=max_clients_by_connections,
                 )
+            )
 
         if stream is not None:
-            self._clients[desired_addr].add_stream(stream)
-        assert self._clients[desired_addr].is_started
-        return self._clients[desired_addr]
+            self._clients[desired_addr][len(self._clients[desired_addr]) - 1].add_stream(stream)
+
+        assert self._clients[desired_addr][len(self._clients[desired_addr]) - 1].is_started
+        return self._clients[desired_addr][len(self._clients[desired_addr]) - 1]
 
     async def _resolve_broker(
         self,
@@ -759,6 +784,7 @@ class ClientPool:
         addr: Addr,
         connection_closed_handler: Optional[CB[OnClosedErrorInfo]] = None,
         sasl_configuration_mechanism: SlasMechanism = SlasMechanism.MechanismPlain,
+        max_clients_by_connections: int = 256,
     ) -> Client:
         desired_host, desired_port = addr.host, str(addr.port)
 
@@ -770,6 +796,7 @@ class ClientPool:
                 connection_closed_handler=connection_closed_handler,
                 connection_name=connection_name,
                 sasl_configuration_mechanism=sasl_configuration_mechanism,
+                max_clients_by_connections=max_clients_by_connections,
             )
 
             assert client.server_properties is not None
@@ -795,6 +822,7 @@ class ClientPool:
         addr: Addr,
         connection_closed_handler: Optional[CB[OnClosedErrorInfo]] = None,
         sasl_configuration_mechanism: SlasMechanism = SlasMechanism.MechanismPlain,
+        max_clients_by_connections: int = 256,
     ) -> Client:
         host, port = addr
         client = Client(
@@ -806,6 +834,7 @@ class ClientPool:
             connection_name=connection_name,
             connection_closed_handler=connection_closed_handler,
             sasl_configuration_mechanism=sasl_configuration_mechanism,
+            max_clients_by_connections=max_clients_by_connections,
         )
         await client.start()
         await client.authenticate(
@@ -816,7 +845,8 @@ class ClientPool:
         return client
 
     async def close(self) -> None:
-        for client in list(self._clients.values()):
-            await client.close()
+        for addr in self._clients.values():
+            for client in addr:
+                await client.close()
 
         self._clients.clear()

--- a/rstream/consumer.py
+++ b/rstream/consumer.py
@@ -8,6 +8,7 @@ import ssl
 from collections import defaultdict
 from dataclasses import dataclass
 from functools import partial
+from random import randrange
 from typing import (
     Annotated,
     Any,
@@ -469,6 +470,7 @@ class Consumer:
 
     async def reconnect_stream(self, stream: str, offset: Optional[int] = None) -> None:
         logging.debug("reconnect_stream")
+        await asyncio.sleep(randrange(3))
         curr_subscriber = None
         curr_subscriber_id = None
         for subscriber_id in self._subscribers:

--- a/rstream/consumer.py
+++ b/rstream/consumer.py
@@ -80,6 +80,7 @@ class Consumer:
         heartbeat: int = 60,
         load_balancer_mode: bool = False,
         max_retries: int = 20,
+        max_subscribers_by_connection: int = 256,
         on_close_handler: Optional[CB_CONN[OnClosedErrorInfo]] = None,
         connection_name: str = None,
         sasl_configuration_mechanism: SlasMechanism = SlasMechanism.MechanismPlain,
@@ -108,6 +109,7 @@ class Consumer:
         self._sasl_configuration_mechanism = sasl_configuration_mechanism
         if self._connection_name is None:
             self._connection_name = "rstream-consumer"
+        self._max_subscribers_by_connection = max_subscribers_by_connection
 
     @property
     async def default_client(self) -> Client:
@@ -127,6 +129,7 @@ class Consumer:
             connection_closed_handler=self._on_close_handler,
             connection_name=self._connection_name,
             sasl_configuration_mechanism=self._sasl_configuration_mechanism,
+            max_clients_by_connections=self._max_subscribers_by_connection,
         )
 
     def stop(self) -> None:
@@ -159,6 +162,7 @@ class Consumer:
                 self._default_client = await self._pool.get(
                     connection_closed_handler=self._on_close_handler,
                     connection_name=self._connection_name,
+                    max_clients_by_connections=self._max_subscribers_by_connection,
                 )
 
             leader, replicas = await (await self.default_client).query_leader_and_replicas(stream)
@@ -169,6 +173,7 @@ class Consumer:
                 connection_closed_handler=self._on_close_handler,
                 connection_name=self._connection_name,
                 stream=stream,
+                max_clients_by_connections=self._max_subscribers_by_connection,
             )
 
             await self._close_locator_connection()

--- a/rstream/consumer.py
+++ b/rstream/consumer.py
@@ -470,7 +470,6 @@ class Consumer:
 
     async def reconnect_stream(self, stream: str, offset: Optional[int] = None) -> None:
         logging.debug("reconnect_stream")
-        await asyncio.sleep(randrange(3))
         curr_subscriber = None
         curr_subscriber_id = None
         for subscriber_id in self._subscribers:

--- a/rstream/consumer.py
+++ b/rstream/consumer.py
@@ -8,7 +8,6 @@ import ssl
 from collections import defaultdict
 from dataclasses import dataclass
 from functools import partial
-from random import randrange
 from typing import (
     Annotated,
     Any,

--- a/rstream/superstream_consumer.py
+++ b/rstream/superstream_consumer.py
@@ -84,7 +84,7 @@ class SuperStreamConsumer:
         self.heartbeat = heartbeat
         self.load_balancer_mode = load_balancer_mode
         self.max_retries = max_retries
-        self._consumers: dict[str, Consumer] = {}
+        self._consumer: Optional[Consumer] = None
         self._stop_event = asyncio.Event()
         self._subscribers: dict[str, str] = defaultdict(str)
         self._on_close_handler = on_close_handler
@@ -128,9 +128,8 @@ class SuperStreamConsumer:
         self._stop_event.set()
 
     async def close(self) -> None:
-        for partition in self._consumers:
-            consumer = self._consumers[partition]
-            await consumer.close()
+        if self._consumer is not None:
+            await self._consumer.close()
 
         self.stop()
         await self._pool.close()
@@ -153,9 +152,6 @@ class SuperStreamConsumer:
             )
 
         return self._clients[stream]
-
-    async def get_consumer(self, partition: str):
-        return self._consumers[partition]
 
     async def subscribe(
         self,
@@ -182,12 +178,10 @@ class SuperStreamConsumer:
         self._super_stream_metadata = DefaultSuperstreamMetadata(self.super_stream, self._default_client)
         partitions = await self._super_stream_metadata.partitions()
 
+        if self._consumer is None:
+            self._consumer = await self._create_consumer()
         for partition in partitions:
-            if partition not in self._consumers.keys():
-                consumer = await self._create_consumer()
-                self._consumers[partition] = consumer
-
-            consumer_partition: Optional[Consumer] = self._consumers.get(partition)
+            consumer_partition: Optional[Consumer] = self._consumer
             if consumer_partition is None:
                 return
 
@@ -231,17 +225,18 @@ class SuperStreamConsumer:
         logger.debug("unsubscribe(): unsubscribe superstream consumer unsubscribe all consumers")
         partitions = await self._super_stream_metadata.partitions()
         for partition in partitions:
-            if self._consumers[partition] is None:
-                self._consumers[partition] = await self._create_consumer()
-
-            consumer = self._consumers[partition]
-            await consumer.unsubscribe(self._subscribers[partition])
+            consumer = self._consumer
+            if consumer is not None:
+                await consumer.unsubscribe(self._subscribers[partition])
 
     async def reconnect_stream(self, stream: str, offset: Optional[int] = None) -> None:
-        await self._consumers[stream].reconnect_stream(stream, offset)
+        if self._consumer is not None:
+            await self._consumer.reconnect_stream(stream, offset)
 
     async def stream_exists(self, stream: str) -> bool:
-        stream_exist = await self._consumers[stream].stream_exists(stream)
+        stream_exist = False
+        if self._consumer is not None:
+            stream_exist = await self._consumer.stream_exists(stream)
         return stream_exist
 
     async def create_super_stream(
@@ -284,10 +279,10 @@ class SuperStreamConsumer:
         # clean up the subscribers
         if super_stream == self.super_stream:
             for partition in self._partitions:
-                if partition in self._consumers:
-                    consumer = self._consumers[partition]
+                consumer = self._consumer
+                if consumer is not None:
                     await consumer.clean_up_subscribers(partition)
-                self._partitions = []
+            self._partitions = []
 
         try:
             await (await self.default_client).delete_super_stream(super_stream)


### PR DESCRIPTION
This closes #182 

This PR is changing the client layer so a few more tests need to be done.

Now the Producer/SuperstreamProducer and Consumer/Superstreamconsumer classes take a new fields: max_publishers_by_connection and max_subscribers_by_connection

In this way you can setup the maximum publishers and subscribers by connections (Before was 256 without possibility to override this value).

Doing some tests with this mode I was also able to discover a bug in client.get_available_id

Also It improves the SuperstreamConsumer connections.
Before the class was creating a new Consumer for every partition of the superstream, while now we are just using a single Consumer and creating different Subscribers.