### PR TITLE
cancelling background task before publishing remaining items

### DIFF
--- a/rstream/producer.py
+++ b/rstream/producer.py
@@ -168,9 +168,9 @@ class Producer:
 
         logger.debug("close(): Stopping background ingestion task and publish pending items")
         if self.task is not None:
+            self.task.cancel()
             for stream in self._buffered_messages:
                 await self._publish_buffered_messages(stream)
-            self.task.cancel()
 
         self._close_called = True
 


### PR DESCRIPTION
This will avoid an asyncio.CancelledError in _publish_buffered_messages during the close() of the Producer that sometimes happens 