### PR TITLE
adding typing_extensions on non dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rstream"
-version = "0.20.0"
+version = "0.20.1"
 description = "A python client for RabbitMQ Streams"
 authors = ["George Fortunatov <qweeeze@gmail.com>", "Daniele Palaia <dpalaia@vmware.com>"]
 readme = "README.md"
@@ -12,6 +12,7 @@ license = "MIT"
 python = "^3.9"
 requests = "^2.31.0"
 mmh3 = "^4.0.0"
+typing_extensions ="^4.11.0"
 
 [tool.poetry.dev-dependencies]
 ipython = "^7.13.0"


### PR DESCRIPTION
Allow typing_extensions to be included on release version (at the moment it is just in the dev dependencies)