### PR TITLE
Fixed a bug when, after unsubscribing, the next subscriber with the same subscriber name used a first subscriber callback and ignore second subscriber callback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,12 +330,12 @@ Run the server with the following command:
 ```bash
 docker run -it --rm --name rabbitmq -p 5552:5552 -p 5672:5672 -p 15672:15672 \
     -e RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS='-rabbitmq_stream advertised_host localhost' \
-    rabbitmq:3.12-management
+    rabbitmq:3.13.1-management
 ```
 
 enable the plugin:
 ```bash
-docker exec rabbitmq rabbitmq-plugins enable rabbitmq_stream
+docker exec rabbitmq rabbitmq-plugins enable rabbitmq_stream rabbitmq_stream_management rabbitmq_amqp1_0
 ```
 
 and run the tests:

--- a/rstream/consumer.py
+++ b/rstream/consumer.py
@@ -304,6 +304,8 @@ class Consumer:
     async def unsubscribe(self, subscriber_name: str) -> None:
         logger.debug("unsubscribe(): UnSubscribing and removing handlers")
         subscriber = self._subscribers[subscriber_name]
+
+        await subscriber.client.stop_queue_listener_task(subscriber_name=subscriber_name)
         subscriber.client.remove_handler(
             schema.Deliver,
             name=subscriber.reference,


### PR DESCRIPTION
Good day!

I found a bug and suggest a solution.

```
import asyncio

from rstream import Consumer, AMQPMessage
from rstream import MessageContext
from rstream import Producer


async def main():
    consumer = Consumer(host="rabbitmq", username="guest", password="guest")

    producer = Producer(host="rabbitmq", username="guest", password="guest")

    await consumer.start()

    async def cb1(message: AMQPMessage, context: MessageContext):

        print(f"cb1: {context.offset}")

    async def cb2(message: AMQPMessage, context: MessageContext):
        print(f"cb2: {context.offset}")

    await consumer.create_stream(stream="kek", exists_ok=True)

    subscriber_name1 = await consumer.subscribe("kek", cb1)

    await producer.send_wait(stream="kek", message=b"123")

    await asyncio.sleep(5)

    await consumer.unsubscribe(subscriber_name=subscriber_name1)

    subscriber_name2 = await consumer.subscribe("kek", cb2)

    await asyncio.sleep(5)


asyncio.run(main())

```

Expected output for this code:

```
cb1: 0
cb2: 0
```


Actual Output:
```
cb1: 0
cb1: 0
```