### PR TITLE
reset heartbeat timeout when receiving any response from the server

### DIFF
--- a/rstream/client.py
+++ b/rstream/client.py
@@ -272,6 +272,9 @@ class BaseClient:
                 if not self.is_connection_alive():
                     break
 
+                # reset heartbeat time when we receive any response from the socket
+                self._last_heartbeat = time.monotonic()
+
                 logger.debug("Received frame: %s", frame)
 
                 _key = frame.key, frame.corr_id


### PR DESCRIPTION
This will close https://github.com/qweeze/rstream/issues/203

At the moment we reset the _last_heartbeat just when we receive an heartbeat response from the server.

This reset should happen everytime we receive a response from server (as per other clients)