### PR TITLE
Fixed bugs of exception logging

### DIFF
--- a/rstream/client.py
+++ b/rstream/client.py
@@ -361,9 +361,9 @@ class BaseClient:
                     )
 
                 except asyncio.TimeoutError:
-                    logger.warning("timeout in client close() sync_request:")
-                except BaseException as exc:
-                    logger.exception("exception in client close() sync_request", exc)
+                    logger.warning("timeout in client close() sync_request")
+                except BaseException:
+                    logger.exception("exception in client close() sync_request")
 
         self._is_not_closed = False
         await asyncio.sleep(0.2)

--- a/rstream/consumer.py
+++ b/rstream/consumer.py
@@ -321,7 +321,7 @@ class Consumer:
         except asyncio.TimeoutError:
             logger.warning("timeout when closing consumer and deleting publisher")
         except BaseException as exc:
-            logger.warning("exception in unsubscribe of Consumer:" + str(exc))
+            logger.warning("exception in unsubscribe of Consumer: %s", exc)
 
         stream = subscriber.stream
 

--- a/rstream/producer.py
+++ b/rstream/producer.py
@@ -181,8 +181,8 @@ class Producer:
                     await asyncio.wait_for(publisher.client.delete_publisher(publisher.id), 5)
                 except asyncio.TimeoutError:
                     logger.warning("timeout when closing producer and deleting publisher")
-                except BaseException as exc:
-                    logger.exception("exception in delete_publisher in Producer.close:", exc)
+                except BaseException:
+                    logger.exception("exception in delete_publisher in Producer.close")
             publisher.client.remove_handler(schema.PublishConfirm, publisher.reference)
             publisher.client.remove_handler(schema.PublishError, publisher.reference)
             publisher.client.remove_handler(schema.MetadataUpdate, publisher.reference)
@@ -262,11 +262,11 @@ class Producer:
 
         except StreamDoesNotExist as e:
             await self._maybe_clean_up_during_lost_connection(stream)
-            logger.exception("Error in _get_or_create_publisher: stream does not exists anymore", e)
+            logger.exception("Error in _get_or_create_publisher: stream does not exists anymore")
             raise e
         except Exception as ex:
             await self._maybe_clean_up_during_lost_connection(stream)
-            logger.exception("error declaring publisher: ", ex)
+            logger.exception("error declaring publisher")
             raise ex
 
         logger.debug("_get_or_create_publisher(): Adding handlers")
@@ -615,10 +615,10 @@ class Producer:
                 for stream in self._buffered_messages:
                     try:
                         await self._publish_buffered_messages(stream)
-                    except BaseException as exc:
-                        logger.exception("producer _timer exception: ", {exc})
-        except Exception as ex:
-            logger.exception("exception in _timer: " + str(ex))
+                    except BaseException:
+                        logger.exception("producer _timer exception")
+        except Exception:
+            logger.exception("exception in _timer")
 
     async def _publish_buffered_messages(self, stream: str) -> None:
         logger.debug("publishing message with _publish_buffered_messages")


### PR DESCRIPTION
```
--- Logging error ---
Traceback (most recent call last):
  File "/home/app/.local/lib/python3.12/site-packages/rstream/producer.py", line 236, in _get_or_create_publisher
    client = await self._get_or_create_client(stream)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/app/.local/lib/python3.12/site-packages/rstream/producer.py", line 211, in _get_or_create_client
    self._clients[stream] = await self._pool.get(
                            ^^^^^^^^^^^^^^^^^^^^^
  File "/home/app/.local/lib/python3.12/site-packages/rstream/client.py", line 768, in get
    await self.new(
  File "/home/app/.local/lib/python3.12/site-packages/rstream/client.py", line 841, in new
    await client.start()
  File "/home/app/.local/lib/python3.12/site-packages/rstream/client.py", line 236, in start
    await self._conn.open()
  File "/home/app/.local/lib/python3.12/site-packages/rstream/connection.py", line 37, in open
    self._reader, self._writer = await asyncio.wait_for(
                                 ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/asyncio/tasks.py", line 520, in wait_for
    return await fut
           ^^^^^^^^^
  File "/usr/local/lib/python3.12/asyncio/streams.py", line 48, in open_connection
    transport, _ = await loop.create_connection(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/asyncio/base_events.py", line 1129, in create_connection
    raise OSError('Multiple exceptions: {}'.format(
OSError: Multiple exceptions: [Errno 111] Connect call failed ('::1', 5552, 0, 0), [Errno 111] Connect call failed ('127.0.0.1', 5552)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.12/logging/__init__.py", line 1160, in emit
    msg = self.format(record)
          ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/logging/__init__.py", line 999, in format
    return fmt.format(record)
           ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/logging/__init__.py", line 703, in format
    record.message = record.getMessage()
                     ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/logging/__init__.py", line 392, in getMessage
    msg = msg % self.args
          ~~~~^~~~~~~~~~~
TypeError: not all arguments converted during string formatting
Call stack:
  File "/usr/local/lib/python3.12/threading.py", line 1032, in _bootstrap
    self._bootstrap_inner()
  File "/usr/local/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.12/threading.py", line 1012, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.12/asyncio/base_events.py", line 641, in run_forever
    self._run_once()
  File "/usr/local/lib/python3.12/asyncio/base_events.py", line 1986, in _run_once
    handle._run()
  File "/usr/local/lib/python3.12/asyncio/events.py", line 88, in _run
    self._context.run(self._callback, *self._args)
  File "/home/app/.local/lib/python3.12/site-packages/rstream/producer.py", line 617, in _timer
    await self._publish_buffered_messages(stream)
  File "/home/app/.local/lib/python3.12/site-packages/rstream/producer.py", line 627, in _publish_buffered_messages
    await self._send_batch_async(stream, self._buffered_messages[stream])
  File "/home/app/.local/lib/python3.12/site-packages/rstream/producer.py", line 415, in _send_batch_async
    publisher = await self._get_or_create_publisher(
  File "/home/app/.local/lib/python3.12/site-packages/rstream/producer.py", line 269, in _get_or_create_publisher
    logger.exception("error declaring publisher: ", ex)
Message: 'error declaring publisher: '
Arguments: (OSError("Multiple exceptions: [Errno 111] Connect call failed ('::1', 5552, 0, 0), [Errno 111] Connect call failed ('127.0.0.1', 5552)"),)
```
