### PR TITLE
Jump to 0.30 to align the tags to the versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rstream"
-version = "0.21.0"
+version = "0.30.0"
 description = "A python client for RabbitMQ Streams"
 authors = ["George Fortunatov <qweeeze@gmail.com>", "Daniele Palaia <dpalaia@vmware.com>", "Gabriele Santomaggio <g.santomaggio@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
We now jump to version 0.30 to align the versions with the tags.