### PR TITLE
fix(packaging): declare PEP 517 build-system for sdist installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- Declare a PEP 517 `[build-system]` in `pyproject.toml` so pip can build wheels from the source distribution with the correct package metadata (version and files), fixing installs with `pip install --no-binary rstream`. ([#270](https://github.com/rabbitmq-community/rstream/issues/270))
+
 ## [[1.0.0](https://github.com/rabbitmq-community/rstream/releases/tag/v1.0.0)]
 
 This release promotes rstream to 1.0 and includes producer exception handling improvements.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
 [tool.poetry]
 name = "rstream"
-version = "1.0.0"
+version = "1.0.1"
 description = "A python client for RabbitMQ Streams"
 authors = ["Gabriele Santomaggio <g.santomaggio@gmail.com>", "George Fortunatov <qweeeze@gmail.com>", "Daniele Palaia <dpalaia@vmware.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=2.3.2"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]


### PR DESCRIPTION
Add [build-system] with poetry-core so pip can build from the source distribution with correct metadata. Without it, pip install --no-binary rstream could report inconsistent versions (e.g. 0.0.0 vs the release).

Fixes https://github.com/rabbitmq-community/rstream/issues/270



How to test
===
```bash
$ poetry build 
$ python3 -m venv /tmp/rstream-sdist-test
$ source /tmp/rstream-sdist-test/bin/activate
$ pip install -U pip
$ pip install --no-binary rstream pip install --no-binary rstream "$(pwd)/dist/rstream-1.0.1.tar.gz"
```
Then
```
$ pip show rstream
```

You should see:
```
Name: rstream
Version: 1.0.1
Summary: A python client for RabbitMQ Streams
Home-page: https://github.com/rabbitmq-community/rstream
Author: Gabriele Santomaggio
License: MIT
```




